### PR TITLE
New database structure with corresponding indexing/querying APIs

### DIFF
--- a/cosima_cookbook/__init__.py
+++ b/cosima_cookbook/__init__.py
@@ -3,24 +3,4 @@
 Common tools for working with COSIMA model output
 """
 
-__all__ = []
-
-from . import diagnostics
-from . diagnostics import *
-
-from . import plots
-from . plots import *
-
-from . import netcdf_index
-from . netcdf_index import *
-
-from . import summary
-from . summary import *
-
-from . import date_utils
-from . date_utils import *
-
-from . distributed import start_cluster, compute_by_block
-
-__all__.extend(netcdf_index.__all__)
-
+from . import database

--- a/cosima_cookbook/__init__.py
+++ b/cosima_cookbook/__init__.py
@@ -4,3 +4,4 @@ Common tools for working with COSIMA model output
 """
 
 from . import database
+from . import querying

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -1,0 +1,271 @@
+import logging
+from pathlib import Path
+import re
+import subprocess
+
+import cftime
+from dask.distributed import as_completed
+import netCDF4
+from sqlalchemy import create_engine, select, exists, sql
+from sqlalchemy import Table, Column, Integer, String, Boolean, MetaData, ForeignKey
+
+from . import netcdf_utils
+
+def create_database(db, debug=False):
+    """Create new database file with the target schema.
+
+    We create a foreign key constraint on the ncfile column in
+    the ncvars table, but it won't be enforced without `PRAGMA
+    foreign_keys = 1' in sqlite."""
+
+    engine = create_engine('sqlite:///' + db, echo=debug)
+    metadata = MetaData()
+
+    ncfiles = Table('ncfiles', metadata,
+                    Column('id', Integer, primary_key=True),
+                    Column('ncfile', String, index=True, unique=True),
+                    Column('present', Boolean),
+                    Column('experiment', String, index=True),
+                    Column('run', Integer),
+                    Column('timeunits', String),
+                    Column('calendar', String),
+                    Column('time_start', String),
+                    Column('time_end', String),
+                    Column('frequency', String),
+                    )
+
+    ncvars = Table('ncvars', metadata,
+                   Column('id', Integer, primary_key=True),
+                   Column('ncfile', None, ForeignKey('ncfiles.id'), nullable=False, index=True),
+                   Column('variable', String),
+                   Column('dimensions', String),
+                   Column('chunking', String))
+
+    metadata.create_all(engine)
+    return engine.connect(), {'ncfiles': ncfiles, 'ncvars': ncvars}
+
+def file_timeinfo(f):
+    """Extract time information from a single netCDF file: units, calendar,
+    start time, end time, and frequency."""
+
+    timeinfo = {}
+
+    with netCDF4.Dataset(f, 'r') as ds:
+        # we assume the record dimension corresponds to time
+        time_dim = netcdf_utils.find_record_dimension(ds)
+        if time_dim is None:
+            return None
+
+        time_var = ds.variables[time_dim]
+        has_bounds = hasattr(time_var, 'bounds')
+
+        if len(time_var) == 0:
+            return None
+
+        if hasattr(time_var, 'units'):
+            timeinfo['timeunits'] = time_var.units
+        else:
+            timeinfo['timeunits'] = None
+        if hasattr(time_var, 'calendar'):
+            timeinfo['calendar'] = time_var.calendar
+        else:
+            timeinfo['calendar'] = None
+
+        if timeinfo['timeunits'] is None or timeinfo['calendar'] is None:
+            # non CF-compliant file
+            timeinfo['time_start'] = None
+            timeinfo['time_end'] = None
+            timeinfo['frequency'] = None
+            return timeinfo
+
+        def todate(t):
+            return cftime.num2date(t, time_var.units, calendar=time_var.calendar)
+
+        if has_bounds:
+            bounds_var = ds.variables[time_var.bounds]
+            timeinfo['time_start'] = todate(bounds_var[0,0])
+            timeinfo['time_end'] = todate(bounds_var[-1,1])
+        else:
+            timeinfo['time_start'] = todate(time_var[0])
+            timeinfo['time_end'] = todate(time_var[-1])
+
+        if len(time_var) > 1 or has_bounds:
+            # calculate frequency -- I don't see any easy way to do this, so
+            # it's somewhat heuristic
+            #
+            # using bounds_var gets us the averaging period instead of the
+            # difference between the centre of averaging periods, which is easier
+            # to work with
+            if has_bounds:
+                next_time = todate(bounds_var[0,1])
+            else:
+                next_time = todate(time_var[1])
+
+            dt = next_time - timeinfo['time_start']
+            if dt.days >= 365:
+                years = round(dt.days / 365)
+                timeinfo['frequency'] = '{} yearly'.format(years)
+            elif dt.days >= 28:
+                months = round(dt.days / 30)
+                timeinfo['frequency'] = '{} monthly'.format(months)
+            elif dt.days >= 1:
+                timeinfo['frequency'] = '{} daily'.format(dt.days)
+            else:
+                timeinfo['frequency'] = '{} hourly'.format(dt.seconds // 3600)
+        else:
+            # single time value in this file and no averaging
+            timeinfo['frequency'] = 'static'
+
+        # convert start/end times to timestamps
+        # strftime doesn't like years with fewer than 4 digits (pads with spaces
+        # instead of zeroes)...
+        def zeropad(s):
+            ss = s.lstrip()
+            return (len(s)-len(ss))*'0' + ss
+
+        timeinfo['time_start'] = zeropad(timeinfo['time_start'].strftime('%Y-%m-%d %H:%M:%S'))
+        timeinfo['time_end'] = zeropad(timeinfo['time_end'].strftime('%Y-%m-%d %H:%M:%S'))
+
+    return timeinfo
+
+def index_file(f):
+    """Index a single netCDF file by retrieving all variables, their dimensions
+    and chunking.
+
+    Returns a list of dictionaries."""
+
+    with netCDF4.Dataset(f, 'r') as ds:
+        ncvars = [{'variable': v.name,
+                   'dimensions': str(v.dimensions),
+                   'chunking': str(v.chunking())}
+                  for v in ds.variables.values()]
+
+    return ncvars
+
+def index_run(run_dir, db, update=False):
+    """Index all output files for a single run (i.e. an outputNNN directory).
+
+    Pass update=True to try to optimise by not touching files already in the
+    database (may run into sqlite concurrency errors)."""
+
+    # find all netCDF files in the hierarchy below this directory
+    files = []
+    try:
+        results = subprocess.check_output(['find', run_dir, '-name', '*.nc'])
+        results = [s for s in results.decode('utf-8').split()]
+        files.extend(results)
+    except Exception as e:
+        logging.error('Error occurred while finding output files: %s', e)
+
+    # extract experiment and run from path
+    expt = Path(run_dir).parent.name
+    run = 0
+    m = re.search(r'\d+$', Path(run_dir).name)
+    if m:
+        run = int(m.group())
+    else:
+        logging.warning('Unconvention run directory: %s', run_dir)
+
+    results = []
+    if update:
+        query_conn, tables = create_database(db)
+
+    for f in files:
+        # skip processing file if it's already in the database
+        # (since we treat files atomically, it's either there or not)
+        if update and query_conn.execute(select([tables['ncfiles'].c.id]) \
+                                         .where(tables['ncfiles'].c.ncfile == f)).fetchone() is not None:
+            continue
+
+        # try to index this file, and mark it 'present' if indexing succeeds
+        file_present = False
+        timeinfo = None
+        try:
+            ncvars = index_file(f)
+            file_present = True
+            timeinfo = file_timeinfo(f)
+        except FileNotFoundError:
+            logging.info('Unable to find file: %s', f)
+        except Exception as e:
+            logging.error('Error indexing %s: %s', f, e)
+
+        info = {'ncfile': f,
+                'experiment': expt,
+                'run': run,
+                'present': file_present,
+                'vars': ncvars}
+        if timeinfo is not None:
+            info.update(timeinfo)
+
+        results.append(info)
+
+    if update:
+        query_conn.close()
+
+    return results
+
+def build_index(directories, client, db, update=False, debug=False):
+    """Index all runs contained within a directory. Requires a distributed client for processing,
+    and the filename of a database that's been created with the create_database() function.
+
+    May scan for only new entries to add to database with the update flag."""
+
+    # make the assumption that everything has been created with payu -- all output data is a
+    # child of an `output???' directory
+    runs = []
+    if not isinstance(directories, list):
+        directories = [directories]
+
+    for directory in directories:
+        try:
+            results = subprocess.check_output(['find', directory, '-maxdepth', '3', '-type', 'd',
+                                               '-name', 'output???', '-prune'])
+            results = [s for s in results.decode('utf-8').split()]
+            runs.extend(results)
+        except Exception as e:
+            logging.error('Error occurred while finding output directories: %s', e)
+            return None
+
+    conn, tables = create_database(db, debug=debug)
+
+    if update:
+        # this is a bit of a crazy optimisation:
+        # pop all the output directories in a temporary table in the database
+        # select out only those that haven't already had a file indexed
+        # instead of using a 'like' clause, we manually do the string comparison,
+        # because sqlite doesn't realise it can use our index on the ncfile column...
+        metadata = MetaData()
+        cand = Table('candidates', metadata,
+                     Column('id', Integer, primary_key=True),
+                     Column('rundir', Text),
+                     Column('rundir2', Text))
+        conn.execute('CREATE TEMP TABLE candidates (id INTEGER PRIMARY KEY, rundir TEXT, rundir2 TEXT)')
+        conn.execute(cand.insert(), [{'rundir': run, 'rundir2': run[:-1] + chr(ord(run[-1]) + 1)} for run in runs])
+        s = select([cand.c.rundir]).where(sql.not_(exists()
+                                                   .where(tables['ncfiles'].c.ncfile >= cand.c.rundir)
+                                                   .where(tables['ncfiles'].c.ncfile < cand.c.rundir2)))
+        r = conn.execute(s)
+        runs = [run[0] for run in r.fetchall()]
+
+    # perform the indexing on the client that we've been provided
+    futures = client.map(index_run, runs, db=db, update=update)
+    i = 0
+    n = len(runs)
+    print('{}/{}'.format(i, n), end='', flush=True)
+
+    for future, result in as_completed(futures, with_results=True):
+        i += 1
+        print('\r{}/{}'.format(i, n), end='', flush=True)
+
+        if result is None: continue
+
+        for ncfile in result:
+            r = conn.execute(tables['ncfiles'].insert(), ncfile)
+
+            if not ncfile['present']: continue
+            file_id = r.inserted_primary_key[0]
+
+            ncvars = ncfile['vars']
+            for v in ncvars:
+                v.update(ncfile=file_id)
+            conn.execute(tables['ncvars'].insert(), ncvars)

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -7,7 +7,7 @@ import cftime
 from dask.distributed import as_completed
 import netCDF4
 from sqlalchemy import create_engine, select, exists, sql
-from sqlalchemy import Table, Column, Integer, String, Boolean, MetaData, ForeignKey
+from sqlalchemy import Table, Column, Integer, Text, Boolean, MetaData, ForeignKey
 
 from . import netcdf_utils
 
@@ -23,23 +23,23 @@ def create_database(db, debug=False):
 
     ncfiles = Table('ncfiles', metadata,
                     Column('id', Integer, primary_key=True),
-                    Column('ncfile', String, index=True, unique=True),
+                    Column('ncfile', Text, index=True, unique=True),
                     Column('present', Boolean),
-                    Column('experiment', String, index=True),
+                    Column('experiment', Text, index=True),
                     Column('run', Integer),
-                    Column('timeunits', String),
-                    Column('calendar', String),
-                    Column('time_start', String),
-                    Column('time_end', String),
-                    Column('frequency', String),
+                    Column('timeunits', Text),
+                    Column('calendar', Text),
+                    Column('time_start', Text),
+                    Column('time_end', Text),
+                    Column('frequency', Text),
                     )
 
     ncvars = Table('ncvars', metadata,
                    Column('id', Integer, primary_key=True),
                    Column('ncfile', None, ForeignKey('ncfiles.id'), nullable=False, index=True),
-                   Column('variable', String),
-                   Column('dimensions', String),
-                   Column('chunking', String))
+                   Column('variable', Text),
+                   Column('dimensions', Text),
+                   Column('chunking', Text))
 
     metadata.create_all(engine)
     return engine.connect(), {'ncfiles': ncfiles, 'ncvars': ncvars}

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 from pathlib import Path
 import re
@@ -6,8 +7,8 @@ import subprocess
 import cftime
 from dask.distributed import as_completed
 import netCDF4
-from sqlalchemy import create_engine, select, exists, sql
-from sqlalchemy import Table, Column, Integer, Text, Boolean, MetaData, ForeignKey
+from sqlalchemy import create_engine, select, exists, sql, MetaData
+from sqlalchemy import Table, Column, Integer, Text, Boolean, DateTime, ForeignKey
 
 from . import netcdf_utils
 
@@ -25,6 +26,7 @@ def create_database(db, debug=False):
 
     ncfiles = Table('ncfiles', metadata,
                     Column('id', Integer, primary_key=True),
+                    Column('index_time', DateTime),
                     Column('ncfile', Text, index=True, unique=True),
                     Column('present', Boolean),
                     Column('experiment', Text, index=True),
@@ -272,6 +274,7 @@ def build_index(directories, client, db, update=False, debug=False):
         if result is None: continue
 
         for ncfile in result:
+            ncfile['index_time'] = datetime.now()
             r = conn.execute(tables['ncfiles'].insert(), ncfile)
 
             if not ncfile['present']: continue

--- a/cosima_cookbook/netcdf_utils.py
+++ b/cosima_cookbook/netcdf_utils.py
@@ -1,0 +1,8 @@
+def find_record_dimension(d):
+    """Find the record dimension (i.e. time) in a netCDF4 Dataset."""
+
+    for dim in d.dimensions:
+        if d.dimensions[dim].isunlimited():
+            return dim
+
+    return None

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -7,7 +7,7 @@ from . import database
 
 def getvar(expt, variable, db, ncfile=None, n=None,
            start_time=None, end_time=None, chunks=None,
-           time_units=None, offset=None):
+           time_units=None, offset=None, decode_times=True):
     """For a given experiment, return an xarray DataArray containing the
     specified variable.
 
@@ -19,6 +19,7 @@ def getvar(expt, variable, db, ncfile=None, n=None,
     file.
     Override any chunking by passing a chunks dictionary.
     A time offset in days can also be applied.
+    Time decoding can be disabled by passing decode_times=False
     """
 
     conn, tables = database.create_database(db)
@@ -68,7 +69,7 @@ def getvar(expt, variable, db, ncfile=None, n=None,
 
     # handle time offsetting and decoding
     # TODO: use helper function to find the time variable name
-    if 'time' in (c.lower() for c in ds.coords):
+    if 'time' in (c.lower() for c in ds.coords) and decode_times:
         calendar = ncfiles[0][4]
         tvar = 'time'
         # if dataset uses capitalised variant

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -52,11 +52,17 @@ def getvar(expt, variable, db, ncfile=None, n=None,
         else:
             ncfiles = ncfiles[n:]
 
+    file_chunks = None
+
     # chunking -- use first row/file
-    file_chunks = dict(zip(eval(ncfiles[0][1]), eval(ncfiles[0][2])))
-    # apply caller overrides
-    if chunks is not None:
-        file_chunks.update(chunks)
+    try:
+        file_chunks = dict(zip(eval(ncfiles[0][1]), eval(ncfiles[0][2])))
+        # apply caller overrides
+        if chunks is not None:
+            file_chunks.update(chunks)
+    except NameError:
+        # chunking could be 'contiguous', which doesn't evaluate
+        pass
 
     # the "dreaded" open_mfdata can actually be quite efficient
     # I found that it was important to "preprocess" to select only

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -1,0 +1,99 @@
+import logging
+
+from sqlalchemy import select
+import xarray as xr
+
+from . import database
+
+def getvar(expt, variable, db, ncfile=None, n=None,
+           start_time=None, end_time=None, chunks=None,
+           time_units=None, offset=None):
+    """For a given experiment, return an xarray DataArray containing the
+    specified variable.
+
+    If disambiguation based on filename is required, pass the ncfile
+    argument.
+    A subset of output data can be obtained by either
+    restricting the number of results (use a negative value of n to
+    get the latest n files), or by the time ranges spanned by the
+    file.
+    Override any chunking by passing a chunks dictionary.
+    A time offset in days can also be applied.
+    """
+
+    conn, tables = database.create_database(db)
+
+    # find candidate vars -- base query
+    s = select([tables['ncfiles'].c.ncfile,
+                tables['ncvars'].c.dimensions,
+                tables['ncvars'].c.chunking,
+                tables['ncfiles'].c.timeunits,
+                tables['ncfiles'].c.calendar]) \
+            .select_from(tables['ncvars'].join(tables['ncfiles'])) \
+            .where(tables['ncvars'].c.variable == variable) \
+            .where(tables['ncfiles'].c.experiment == expt) \
+            .order_by(tables['ncfiles'].c.time_start)
+
+    # further constraints
+    if ncfile is not None:
+        s = s.where(tables['ncfiles'].c.ncfile.like('%' + ncfile))
+    if start_time is not None:
+        s = s.where(tables['ncfiles'].c.time_end >= start_time)
+    if end_time is not None:
+        s = s.where(tables['ncfiles'].c.time_start <= end_time)
+
+    ncfiles = conn.execute(s).fetchall()
+
+    # restrict number of files directly
+    if n is not None:
+        if n > 0:
+            ncfiles = ncfiles[:n]
+        else:
+            ncfiles = ncfiles[n:]
+
+    # chunking -- use first row/file
+    file_chunks = dict(zip(eval(ncfiles[0][1]), eval(ncfiles[0][2])))
+    # apply caller overrides
+    if chunks is not None:
+        file_chunks.update(chunks)
+
+    # the "dreaded" open_mfdata can actually be quite efficient
+    # I found that it was important to "preprocess" to select only
+    # the relevant variable, because chunking doesn't apply to
+    # all variables present in the file
+    ds = xr.open_mfdataset((f[0] for f in ncfiles), parallel=True,
+                           chunks=file_chunks, autoclose=True,
+                           decode_times=False,
+                           preprocess=lambda d: d[variable].to_dataset())
+
+    # handle time offsetting and decoding
+    # TODO: use helper function to find the time variable name
+    if 'time' in (c.lower() for c in ds.coords):
+        calendar = ncfiles[0][4]
+        tvar = 'time'
+        # if dataset uses capitalised variant
+        if 'Time' in ds.coords:
+            tvar = 'Time'
+
+        # first rebase times onto new units if required
+        if time_units is not None:
+            dates = xr.conventions.times.decode_cf_datetime(ds[tvar], ncfiles[0][3], calendar)
+            times = xr.conventions.times.encode_cf_datetime(dates, time_units, calendar)
+            ds[tvar] = times[0]
+        else:
+            time_units = ncfiles[0][3]
+
+        # time offsetting - mimic one aspect of old behaviour by adding
+        # a fixed number of days
+        if offset is not None:
+            ds[tvar] += offset
+
+
+        # decode time - we assume that we're getting units and a calendar from a file
+        try:
+            decoded_time = xr.conventions.times.decode_cf_datetime(ds[tvar], time_units, calendar)
+            ds[tvar] = decoded_time
+        except Exception as e:
+            logging.error('Unable to decode time: %s', e)
+
+    return ds[variable]

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -71,7 +71,7 @@ def getvar(expt, variable, db, ncfile=None, n=None,
     ds = xr.open_mfdataset((f[0] for f in ncfiles), parallel=True,
                            chunks=file_chunks, autoclose=True,
                            decode_times=False,
-                           preprocess=lambda d: d[variable].to_dataset())
+                           preprocess=lambda d: d[variable].to_dataset() if variable not in d.coords else d)
 
     # handle time offsetting and decoding
     # TODO: use helper function to find the time variable name

--- a/scripts/diag-vis.py
+++ b/scripts/diag-vis.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+import sqlite3
+
+import pandas as pd
+
+from bokeh.io import curdoc
+from bokeh.layouts import column
+from bokeh.models import HoverTool
+from bokeh.models.widgets import Select, Button
+import bokeh.palettes
+from bokeh.plotting import figure
+from bokeh.transform import factor_cmap
+
+dbname = '/g/data/v45/ahg157/cosima/cookbook.db'
+
+expt_query = 'SELECT DISTINCT experiment FROM ncfiles'
+vars_query = '''SELECT DISTINCT ncvars.variable FROM ncvars
+                LEFT JOIN ncfiles ON ncvars.ncfile = ncfiles.id
+                WHERE ncfiles.experiment = ?'''
+data_query = '''SELECT ncfiles.ncfile, run, variable, time_start, time_end, frequency FROM ncfiles
+                LEFT JOIN ncvars ON ncfiles.id = ncvars.ncfile
+                WHERE ncfiles.experiment = ? AND time_start NOT NULL AND frequency <> 'static'
+                ORDER BY variable, time_start'''
+
+def get_data(expt):
+    data = conn.execute(data_query, (expt,)).fetchall()
+    df = pd.DataFrame(data, columns=['ncfile', 'run', 'variable', 'time_start', 'time_end', 'frequency'])
+    df[['time_start', 'time_end']] = df[['time_start', 'time_end']].applymap(
+        lambda s: datetime.strptime(s, '%Y-%m-%d %H:%M:%S'))
+
+    return df
+
+conn = sqlite3.connect(dbname)
+expts = [e[0] for e in conn.execute(expt_query)]
+
+# create widgets
+expt_select = Select(title='Experiment:', options=expts, value='1deg_jra55v13_iaf_spinup1_A')
+refresh = Button(label='Update')
+
+# hover tools
+hover = HoverTool(tooltips=[
+    ('variable', '@variable'), ('start', '@time_start{%F}'),
+    ('end', '@time_end{%F}'), ('run', '@run'), ('file', '@ncfile')],
+                  formatters={
+                      'time_start': 'datetime',
+                      'time_end': 'datetime'
+                      })
+tools = [hover, 'box_select', 'pan', 'box_zoom', 'wheel_zoom', 'reset']
+
+df = get_data(expt_select.value)
+freqs = df.frequency.unique()
+cmap = factor_cmap('frequency', palette=bokeh.palettes.Category10[10], factors=freqs)
+
+p = figure(y_range=df.variable.unique(), x_range=(df.iloc[0].time_start, df.iloc[-1].time_end),
+           title=expt_select.value, tools=tools)
+cmap = factor_cmap('frequency', palette=bokeh.palettes.Category10[10], factors=freqs)
+hb = p.hbar(y='variable', left='time_start', right='time_end', height=0.4, source=df,
+            fill_color=cmap, legend='frequency')
+
+# callback routines to repopulate list of variables
+def get_vars(expt):
+    return [e[0] for e in conn.execute(vars_query, (expt,))]
+
+def refresh_output():
+    # get new data
+    df = get_data(expt_select.value)
+    freqs = df.frequency.unique()
+    cmap = factor_cmap('frequency', palette=bokeh.palettes.Category10[10], factors=freqs)
+
+    # update figure itself
+    p.y_range.factors = list(df.variable.unique())
+    (p.x_range.start, p.x_range.end) = (df.iloc[0].time_start, df.iloc[-1].time_end)
+    p.title.text = expt_select.value
+
+    # update data source for plot
+    hb.data_source.data = hb.data_source.from_df(df)
+    # update colourmap if necessary
+    hb.glyph.fill_color = cmap
+    
+refresh.on_click(refresh_output)
+
+# layout and show
+layout = column(expt_select, refresh, p)
+curdoc().add_root(layout)

--- a/scripts/diag-vis.py
+++ b/scripts/diag-vis.py
@@ -1,41 +1,78 @@
 from datetime import datetime
-import sqlite3
+from sys import argv
 
+import cosima_cookbook as cc
 import pandas as pd
+from sqlalchemy import select, distinct, bindparam
 
 from bokeh.io import curdoc
 from bokeh.layouts import column
-from bokeh.models import HoverTool
-from bokeh.models.widgets import Select, Button
+from bokeh.models.callbacks import CustomJS
+from bokeh.models.sources import ColumnDataSource
+from bokeh.models.tools import BoxSelectTool, HoverTool, TapTool
+from bokeh.models.widgets import Select, Button, Div
 import bokeh.palettes
 from bokeh.plotting import figure
 from bokeh.transform import factor_cmap
 
-dbname = '/g/data/v45/ahg157/cosima/cookbook.db'
+if len(argv) < 2:
+    raise Exception('Usage: bokeh serve diag-vis.py --args <db>')
+db = argv[1]
 
-expt_query = 'SELECT DISTINCT experiment FROM ncfiles'
-vars_query = '''SELECT DISTINCT ncvars.variable FROM ncvars
-                LEFT JOIN ncfiles ON ncvars.ncfile = ncfiles.id
-                WHERE ncfiles.experiment = ?'''
-data_query = '''SELECT ncfiles.ncfile, run, variable, time_start, time_end, frequency FROM ncfiles
-                LEFT JOIN ncvars ON ncfiles.id = ncvars.ncfile
-                WHERE ncfiles.experiment = ? AND time_start NOT NULL AND frequency <> 'static'
-                ORDER BY variable, time_start'''
+conn, tables = cc.database.create_database(db)
+
+expt_query = select([distinct(tables['ncfiles'].c.experiment)])
+vars_query = select([distinct(tables['ncvars'].c.variable)]) \
+             .select_from(tables['ncvars'].join(tables['ncfiles'])) \
+             .where(tables['ncfiles'].c.experiment == bindparam('expt'))
+data_query = select([tables['ncfiles'].c.ncfile, tables['ncfiles'].c.run, tables['ncvars'].c.variable,
+                     tables['ncfiles'].c.time_start, tables['ncfiles'].c.time_end, tables['ncfiles'].c.frequency]) \
+             .select_from(tables['ncfiles'].join(tables['ncvars'])) \
+             .where(tables['ncfiles'].c.experiment == bindparam('expt')) \
+             .where(tables['ncfiles'].c.time_start is not None) \
+             .where(tables['ncfiles'].c.frequency != 'static') \
+             .order_by(tables['ncvars'].c.variable, tables['ncfiles'].c.time_start)
+
+expts = [e[0] for e in conn.execute(expt_query)]
 
 def get_data(expt):
-    data = conn.execute(data_query, (expt,)).fetchall()
+    data = conn.execute(data_query, expt=expt).fetchall()
     df = pd.DataFrame(data, columns=['ncfile', 'run', 'variable', 'time_start', 'time_end', 'frequency'])
     df[['time_start', 'time_end']] = df[['time_start', 'time_end']].applymap(
         lambda s: datetime.strptime(s, '%Y-%m-%d %H:%M:%S'))
 
     return df
 
-conn = sqlite3.connect(dbname)
-expts = [e[0] for e in conn.execute(expt_query)]
+def print_selected(div):
+    return CustomJS(args=dict(div=div), code="""
+var source = cb_obj;
+var unique_vars = {};
+for (var i of source.selected['1d'].indices) {
+  var v = source.data['variable'][i];
+  if (v in unique_vars) {
+    unique_vars[v]['time_start'] = Math.min(unique_vars[v]['time_start'], source.data['time_start'][i]);
+    unique_vars[v]['time_end'] = Math.max(unique_vars[v]['time_end'], source.data['time_end'][i]);
+  } else {
+    unique_vars[v] = { time_start: source.data['time_start'][i],
+                       time_end: source.data['time_end'][i] };
+  }
+}
+
+var text = '<table><tr><th>Name</th><th>Start</th><th>End<th></tr>';
+for (var p in unique_vars) {
+  var ts = new Date(unique_vars[p]['time_start']);
+  var te = new Date(unique_vars[p]['time_end']);
+  text = text.concat('<tr><th>'+p+'</th><td>'+ts.toISOString().substr(0,10)+'</td><td>'+te.toISOString().substr(0,10)+'</td></tr>');
+}
+text = text.concat('</table>')
+div.text = text;
+""")
+
 
 # create widgets
-expt_select = Select(title='Experiment:', options=expts, value='1deg_jra55v13_iaf_spinup1_A')
+expt_select = Select(title='Experiment:', options=expts, value=expts[0])
 refresh = Button(label='Update')
+div = Div(width=1000)
 
 # hover tools
 hover = HoverTool(tooltips=[
@@ -45,21 +82,24 @@ hover = HoverTool(tooltips=[
                       'time_start': 'datetime',
                       'time_end': 'datetime'
                       })
-tools = [hover, 'box_select', 'pan', 'box_zoom', 'wheel_zoom', 'reset']
+tap = TapTool()
+box_select = BoxSelectTool()
+tools = [hover, box_select, tap, 'pan', 'box_zoom', 'wheel_zoom', 'reset']
 
 df = get_data(expt_select.value)
 freqs = df.frequency.unique()
 cmap = factor_cmap('frequency', palette=bokeh.palettes.Category10[10], factors=freqs)
+cds = ColumnDataSource(df, callback=print_selected(div))
 
 p = figure(y_range=df.variable.unique(), x_range=(df.iloc[0].time_start, df.iloc[-1].time_end),
            title=expt_select.value, tools=tools)
 cmap = factor_cmap('frequency', palette=bokeh.palettes.Category10[10], factors=freqs)
-hb = p.hbar(y='variable', left='time_start', right='time_end', height=0.4, source=df,
+hb = p.hbar(y='variable', left='time_start', right='time_end', height=0.4, source=cds,
             fill_color=cmap, legend='frequency')
 
 # callback routines to repopulate list of variables
 def get_vars(expt):
-    return [e[0] for e in conn.execute(vars_query, (expt,))]
+    return [e[0] for e in conn.execute(vars_query, expt=expt)]
 
 def refresh_output():
     # get new data
@@ -80,5 +120,5 @@ def refresh_output():
 refresh.on_click(refresh_output)
 
 # layout and show
-layout = column(expt_select, refresh, p)
+layout = column(expt_select, refresh, p, div)
 curdoc().add_root(layout)

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ setup(
         'joblib',
         'matplotlib',
         'bokeh',
-        'dataset',
         'dask',
-        'distributed',
         'netcdf4',
         'f90nml',
-        'tqdm'
+        'tqdm',
+        'sqlalchemy',
+        'cftime'
         ],
     test_suite='nose.collector',
     tests_require=['nose'],


### PR DESCRIPTION
Here's the early implementation of the newly structured database. We can remove a lot of redundant information with the observation that there is a *has many* relationship between files and variables. This makes building and querying the database significantly faster (closes #103), and should also aid in data discovery (#102; there's an example script to show available diagnostics and their frequency). Along with this, there are fewer assumptions about the structure of the data; we only expect the following structure `<experiment>/output???/**/*.nc` (although @aidanheerdegen has pointed out that perhaps we can relax this further, and I agree). It's fairly simple to specify the location of the database file, and which directories should be indexed (closes #84).

On the querying front, I've implemented a new function, similar to `get_nc_variable` but different in a few ways. Firstly, it returns an xarray structure that more efficiently leverages dask to reduce memory pressure (closes #105 and #85). Instead of limiting queries by the number of raw model runs, they can be limited on the actual dates (one limitation I've just realised is that there's no culling of the resultant DataArray so that it lands exactly on these dates...).

There are two notable omissions from this PR as it stands: unit testing and user-level documentation. I haven't looked, but I'm assuming Travis is nearly set up for unit testing the repository, and in particular I'd love to ensure we're not regressing on things like time offsetting which seems quite delicate.

As for documentation, I think example notebooks would be the best first step, especially if we can get the cookbook in the global conda environment so users won't have to worry about manually and individually installing it.