### PR TITLE
Join to experiment table when updating database

### DIFF
--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -330,6 +330,7 @@ def index_experiment(experiment_dir, session=None, client=None, update=False):
         # first construct a query for the current experiment
         q = (session
              .query(NCFile.ncfile)
+             .join(NCExperiment)
              .filter(NCExperiment.experiment == expt.experiment)
              .filter(NCExperiment.root_dir == expt.root_dir))
 


### PR DESCRIPTION
The missed join means that even though the filters to select the experiment look correct, they're not actually being applied correctly. Fixes #140.