### PR TITLE
Split up and remove offsetting from cc.querying.getvar

### DIFF
--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -379,3 +379,17 @@ def build_index(directories, session, client=None, update=False):
     # if everything went smoothly, commit these changes to the database
     session.commit()
     return indexed
+
+def delete_missing(session, ncfiles):
+    """Given a database session and a list of NCFile objects,
+    ensure the file backing each NCFile exists, else delete
+    it from the database.
+    """
+
+    for f in ncfiles:
+        # check whether file exists
+        if not f.NCFile.ncfile_path.exists():
+            # doesn't exist, update in database
+            session.delete(f.NCFile)
+
+    session.commit()

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -12,6 +12,7 @@ import xarray as xr
 from . import database
 from .database import NCExperiment, NCFile, CFVariable, NCVar
 
+
 class VariableNotFoundError(Exception):
     pass
 
@@ -89,133 +90,97 @@ def get_frequencies(session, experiment=None):
 
     return pd.DataFrame(q)
 
-def getvar(expt, variable, session, ncfile=None, n=None,
-           start_time=None, end_time=None, chunks=None,
-           time_units=None, offset=None, decode_times=True,
-           check_present=False):
+
+def getvar(expt, variable, session, ncfile=None,
+           start_time=None, end_time=None, n=None, **kwargs):
     """For a given experiment, return an xarray DataArray containing the
     specified variable.
-    
-    Parameters
-    ----------
-    expt : str
-        text string indicating the name of the experiment
-    variable : str
-        text string indicating the name of the variable to load
-    session : 
-        a database session created by cc.database.create_session()
-    ncfile
-        If disambiguation based on filename is required, pass the ncfile argument.
-    n
-        A subset of output data can be obtained by restricting the number of 
-        netcdf files to load (use a negative value of n to get the last n 
-        files, or a positive n to get the first n files).
-    start_time 
-        Only load data after this date. Specify the date as a text string
-        (e.g. '1900-1-1')
-    start_time
-        Only load data before this date. Specify the date as a text string
-        (e.g. '1900-1-1')
-    chunks
-        Override any chunking by passing a chunks dictionary.
-    offset
-        A time offset (in an integer number of days) can also be applied.
-    decode_times
-        Time decoding can be disabled by passing decode_times=False
-    check_present
-        indicates whether to check the presence of the file before 
-        loading.
+
+    expt - text string indicating the name of the experiment
+    variable - text string indicating the name of the variable to load
+    session - a database session created by cc.database.create_session()
+    ncfile - may be used if disambiguation based on filename is required
+    start_time - only load data after this date. specify as a text string,
+                 e.g. '1900-01-01'
+    end_time - only load data before this date. specify as a text string,
+               e.g. '1900-01-01'
+    n - after all other queries, restrict the total number of files to the
+        first n. pass a negative value to restrict to the last n
+
+    Note that if start_time and/or end_time are used, the time range
+    of the resulting dataset may not be bounded exactly on those
+    values, depending on where the underlying files start/end. Use
+    dataset.sel() to exactly select times from the dataset.
+
+    Other kwargs are passed through to xarray.open_mfdataset, including:
+
+    chunks - Override any chunking by passing a chunks dictionary.
+    decode_times - Time decoding can be disabled by passing decode_times=False
 
     """
-    f, v = database.NCFile, database.NCVar
-    q = (session
-         .query(f, v)
-         .join(f.ncvars).join(f.experiment)
-         .filter(v.varname == variable)
-         .filter(database.NCExperiment.experiment == expt)
-         .filter(f.present)
-         .order_by(f.time_start))
 
-    # further constraints
+    ncfiles = _ncfiles_for_variable(expt, variable, session, ncfile, start_time, end_time, n)
+
+    # chunking -- use first row/file and assume it's the same across the whole dataset
+    xr_kwargs = {"chunks": _parse_chunks(ncfiles[0].NCVar)}
+    xr_kwargs.update(kwargs)
+
+    ds = xr.open_mfdataset(
+        (str(f.NCFile.ncfile_path) for f in ncfiles),
+        parallel=True,
+        preprocess=lambda d: d[variable].to_dataset()
+        if variable not in d.coords
+        else d,
+        **xr_kwargs
+    )
+
+    return ds[variable]
+
+
+def _ncfiles_for_variable(expt, variable, session,
+                          ncfile=None, start_time=None, end_time=None, n=None):
+    """Return a list of (NCFile, NCVar) pairs corresponding to the
+    database objects for a given variable.
+
+    Optionally, pass ncfile, start_time, end_time or n for additional
+    disambiguation (see getvar documentation for their semantics).
+    """
+
+    f, v = database.NCFile, database.NCVar
+    q = (
+        session.query(f, v)
+        .join(f.ncvars)
+        .join(f.experiment)
+        .filter(v.varname == variable)
+        .filter(database.NCExperiment.experiment == expt)
+        .filter(f.present)
+        .order_by(f.time_start)
+    )
+
+    # additional disambiguation
     if ncfile is not None:
-        q = q.filter(f.ncfile.like('%' + ncfile))
+        q = q.filter(f.ncfile.like("%" + ncfile))
     if start_time is not None:
         q = q.filter(f.time_end >= start_time)
     if end_time is not None:
         q = q.filter(f.time_start <= end_time)
-
     ncfiles = q.all()
 
-    # ensure we actually got a result
-    if not ncfiles:
-        raise VariableNotFoundError("No files were found containing {} in the '{}' experiment".format(variable, expt))
-
-    if check_present:
-        ncfiles_full = ncfiles
-        ncfiles = []
-
-        for f in ncfiles_full:
-            # check whether file exists
-            if f.NCFile.ncfile_path.exists():
-                ncfiles.append(f)
-                continue
-
-            # doesn't exist, update in database
-            session.delete(f.NCFile)
-
-        session.commit()
-
-    # restrict number of files directly
     if n is not None:
         if n > 0:
             ncfiles = ncfiles[:n]
         else:
             ncfiles = ncfiles[n:]
 
-    # chunking -- use first row/file and assume it's the same across the whole dataset
-    file_chunks = _parse_chunks(ncfiles[0].NCVar)
-    # apply caller overrides
-    if chunks is not None:
-        file_chunks.update(chunks)
+    # ensure we actually got a result
+    if not ncfiles:
+        raise VariableNotFoundError(
+            "No files were found containing '{}' in the '{}' experiment".format(
+                variable, expt
+            )
+        )
 
-    # the "dreaded" open_mfdata can actually be quite efficient
-    # I found that it was important to "preprocess" to select only
-    # the relevant variable, because chunking doesn't apply to
-    # all variables present in the file
-    ds = xr.open_mfdataset((str(f.NCFile.ncfile_path) for f in ncfiles), parallel=True,
-                           chunks=file_chunks,
-                           decode_times=False,
-                           preprocess=lambda d: d[variable].to_dataset() if variable not in d.coords else d)
-
-    # handle time offsetting and decoding
-    # TODO: use helper function to find the time variable name
-    if 'time' in (c.lower() for c in ds.coords) and decode_times:
-        tvar = 'time'
-        # if dataset uses capitalised variant
-        if 'Time' in ds.coords:
-            tvar = 'Time'
-
-        # first rebase times onto new units if required
-        if time_units is not None:
-            dates = xr.conventions.times.decode_cf_datetime(ds[tvar], ds[tvar].units, ds[tvar].calendar)
-            times = xr.conventions.times.encode_cf_datetime(dates, time_units, ds[tvar].calendar)
-            ds[tvar] = times[0]
-        else:
-            time_units = ds[tvar].units
-
-        # time offsetting - mimic one aspect of old behaviour by adding
-        # a fixed number of days
-        if offset is not None:
-            ds[tvar] += offset
-
-        # decode time - we assume that we're getting units and a calendar from a file
-        try:
-            decoded_time = xr.conventions.times.decode_cf_datetime(ds[tvar], time_units, ds[tvar].calendar)
-            ds[tvar] = decoded_time
-        except Exception as e:
-            logging.error('Unable to decode time: %s', e)
-
-    return ds[variable]
+    return ncfiles
 
 def _parse_chunks(ncvar):
     """Parse an NCVar, returning a dictionary mapping dimensions to chunking along that dimension."""


### PR DESCRIPTION
See #147 for motivation behind this change. As concluded there, we can't offload everything to `open_mfdataset`, so restriction of the returned file set based on start/end time and overall number of files is retained.

This should be a drop-in change, although offsetting will have to be done as a separate step.

It may be worth merging #129 first (or at least in conjunction with this), because it gives the range of available times for a given variable, in the calendar/units of the files (which are used for the querying).

Closes #143, closes #136, closes #135, closes #113.