### PR TITLE
Clarify SQL join column in queries

### DIFF
--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -22,10 +22,10 @@ def get_experiments(session):
     """
 
     q = (session
-         .query(NCExperiment.experiment, 
+         .query(NCExperiment.experiment,
                 func.count(NCFile.experiment_id).label('ncfiles'))
-         .group_by(NCFile.experiment_id)
-         .join(NCExperiment))
+         .join(NCFile.experiment)
+         .group_by(NCFile.experiment_id))
 
     return pd.DataFrame(q)
 
@@ -36,8 +36,8 @@ def get_ncfiles(session, experiment):
 
     q = (session
          .query(NCFile.ncfile, NCFile.index_time)
-         .join(NCExperiment)
-         .filter(NCExperiment.experiment==experiment))
+         .join(NCFile.experiment)
+         .filter(NCExperiment.experiment == experiment))
 
     return pd.DataFrame(q)
 
@@ -49,7 +49,7 @@ def get_variables(session, experiment, frequency=None):
 
     q = (session
          .query(CFVariable.name, 
-                NCFile.frequency, 
+                NCFile.frequency,
                 NCFile.ncfile,
                 func.count(NCFile.ncfile).label('# ncfiles'),
                 func.min(NCFile.time_start).label('time_start'),
@@ -57,10 +57,10 @@ def get_variables(session, experiment, frequency=None):
          .join(NCFile.experiment)
          .join(NCFile.ncvars)
          .join(NCVar.variable)
-         .filter(NCExperiment.experiment==experiment)
-         .order_by(NCFile.frequency, 
-                   CFVariable.name, 
-                   NCFile.time_start, 
+         .filter(NCExperiment.experiment == experiment)
+         .order_by(NCFile.frequency,
+                   CFVariable.name,
+                   NCFile.time_start,
                    NCFile.ncfile)
          .group_by(CFVariable.name, NCFile.frequency))
 
@@ -82,8 +82,8 @@ def get_frequencies(session, experiment=None):
     else:
         q = (session
              .query(NCFile.frequency)
-             .join(NCExperiment)
-             .filter(NCExperiment.experiment==experiment)
+             .join(NCFile.experiment)
+             .filter(NCExperiment.experiment == experiment)
              .group_by(NCFile.frequency))
 
     return pd.DataFrame(q)


### PR DESCRIPTION
In particular, with SQLAlchemy 1.2.14, the query `session.query(NCExperiment.experiment, ...).join(NCExperiment)` fails because it cannot figure how to construct the join. We should be explicit about the column over which we're joining, to be sure they're executed correctly.