### PR TITLE
Support pruning of deleted files from experiments

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -160,3 +160,28 @@ def test_prune_broken(session_db):
     q = session.query(database.NCFile)
     r = q.all()
     assert(len(r) == 0)
+
+def test_prune_nodelete(session_db, tmpdir):
+    session, db = session_db
+    expt_dir = tmpdir / 'expt'
+    expt_dir.mkdir()
+
+    # copy the file to a new experiment directory and index
+    shutil.copy('test/data/indexing/longnames/output000/test1.nc',
+                str(expt_dir / 'test1.nc'))
+    database.build_index(str(expt_dir), session)
+
+    # check that we have a valid file
+    q = session.query(database.NCFile).filter(database.NCFile.present)
+    r = q.all()
+    assert(len(r) == 1)
+
+    # remove the file and prune
+    os.remove(expt_dir / 'test1.nc')
+    database.prune_experiment('expt', session, delete=False)
+
+    # now we should still have one file, but now not present
+    q = session.query(database.NCFile)
+    r = q.one_or_none()
+    assert(r is not None)
+    assert(not r.present)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -141,3 +141,22 @@ def test_distributed(client, session_db):
     q = session.query(database.NCExperiment)
     r = q.all()
     assert(len(r) == 1)
+
+def test_prune_broken(session_db):
+    session, db = session_db
+    database.build_index('test/data/indexing/broken_file', session)
+
+    assert(db.check())
+
+    # check that we have one file
+    q = session.query(database.NCFile)
+    r = q.all()
+    assert(len(r) == 1)
+
+    # prune experiment
+    database.prune_experiment('broken_file', session)
+
+    # now the database should be empty
+    q = session.query(database.NCFile)
+    r = q.all()
+    assert(len(r) == 0)


### PR DESCRIPTION
The `cc.database.prune_experiment()` function will now check that all files contained within an experiment exist. If not, they can be marked as not present (and won't come up in queries), or removed from the database entirely.

@AndyHoggANU I think this is half of what you wanted. You mentioned also some broken files preventing queries from completing successfully. It'd be handy to have a bit more info about this. Perhaps I could add something like a "verify" function to test that all files returned by a given query are valid/readable?