### PR TITLE
update getvar docstring

### DIFF
--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -101,7 +101,9 @@ def getvar(expt, variable, session, ncfile=None,
     expt - text string indicating the name of the experiment
     variable - text string indicating the name of the variable to load
     session - a database session created by cc.database.create_session()
-    ncfile - may be used if disambiguation based on filename is required
+    ncfile -  an optional text string indicating the pattern for filenames
+              to load. All filenames containing this string will match, so
+              be specific.
     start_time - only load data after this date. specify as a text string,
                  e.g. '1900-01-01'
     end_time - only load data before this date. specify as a text string,

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -103,7 +103,8 @@ def getvar(expt, variable, session, ncfile=None,
     session - a database session created by cc.database.create_session()
     ncfile -  an optional text string indicating the pattern for filenames
               to load. All filenames containing this string will match, so
-              be specific.
+              be specific. '/' can be used to match the start of the
+              filename, and '%' is a wildcard character.
     start_time - only load data after this date. specify as a text string,
                  e.g. '1900-01-01'
     end_time - only load data before this date. specify as a text string,


### PR DESCRIPTION
Following a slack discussion about unexpected behaviour from `cosima_cookbook.querying.getvar`, I'm submitting a possible extension of the docstring.

I'm not sure that this would have prevented my problem, but it does at least tell users that the `ncfile` argument is used for pattern matching, rather than strict matching.

The change is just a suggestion - feedback welcome.