### PR TITLE
Add long_name to output of get_variables

### DIFF
--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -52,7 +52,8 @@ def get_variables(session, experiment, frequency=None):
     """
 
     q = (session
-         .query(CFVariable.name, 
+         .query(CFVariable.name,
+                CFVariable.long_name,
                 NCFile.frequency,
                 NCFile.ncfile,
                 func.count(NCFile.ncfile).label('# ncfiles'),

--- a/test/test_querying.py
+++ b/test/test_querying.py
@@ -110,6 +110,14 @@ def test_get_variables(session):
     df = pd.DataFrame.from_dict(
         {
             "name": ["TLAT", "TLON", "hi_m", "tarea", "time", "time_bounds"],
+            "long_name": [
+                "T grid center latitude",
+                "T grid center longitude",
+                "grid cell mean ice thickness",
+                "area of T grid cells",
+                "model time",
+                "boundaries for time-averaging interval",
+            ],
             "frequency": ["1 monthly"] * 6,
             "ncfile": ["output000/hi_m.nc"] * 6,
             "# ncfiles": [1] * 6,


### PR DESCRIPTION
This should allow for easier discovery of available data. I'm not quite sure what sort of searching you were thinking about @AndyHoggANU -- find variables by their long name, then find experiments containing that variable? Also, I guess this relies on the pandas-based searching we've used before to pare down from the giant variable list, but we could, for example, pre-filter these variables by the long name.