### PR TITLE
Cascade NCFile deletes to NCVars

### DIFF
--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -78,7 +78,7 @@ class NCFile(Base):
     frequency = Column(String)
 
     #: variables in this file
-    ncvars = relationship('NCVar', back_populates='ncfile')
+    ncvars = relationship('NCVar', back_populates='ncfile', cascade='all, delete-orphan')
 
     @property
     def ncfile_path(self):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -222,3 +222,28 @@ def test_prune_nodelete(session_db, tmpdir):
     r = q.one_or_none()
     assert(r is not None)
     assert(not r.present)
+
+def test_prune_delete(session_db, tmpdir):
+    session, db = session_db
+    expt_dir = tmpdir / 'expt'
+    expt_dir.mkdir()
+
+    # copy the file to a new experiment directory and index
+    shutil.copy('test/data/indexing/longnames/output000/test1.nc',
+                str(expt_dir / 'test1.nc'))
+    database.build_index(str(expt_dir), session)
+
+    # check that we have a valid file
+    q = session.query(database.NCFile).filter(database.NCFile.present)
+    r = q.all()
+    assert(len(r) == 1)
+
+    # remove the file and prune
+    os.remove(expt_dir / 'test1.nc')
+    database.prune_experiment('expt', session)
+
+    # now we should still have no files
+    q = session.query(database.NCFile)
+    r = q.one_or_none()
+    assert(r is None)
+


### PR DESCRIPTION
When files are deleted from the databse (such as through `prune_experiment()`), their associated variables need to be deleted since they have a one-to-one relationship.