### PR TITLE
Don't create new tables on outdated databases

### DIFF
--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -150,7 +150,6 @@ def create_session(db=None, debug=False):
         db = os.getenv('COSIMA_COOKBOOK_DB', __DEFAULT_DB__)
 
     engine = create_engine('sqlite:///' + db, echo=debug)
-    Base.metadata.create_all(engine)
 
     # if database version is 0, we've created it anew
     conn = engine.connect()
@@ -160,6 +159,8 @@ def create_session(db=None, debug=False):
         conn.execute('PRAGMA user_version={}'.format(__DB_VERSION__))
     elif ver < __DB_VERSION__:
         raise Exception('Incompatible database versions, expected {}, got {}'.format(ver, __DB_VERSION__))
+
+    Base.metadata.create_all(conn)
     conn.close()
 
     Session = sessionmaker(bind=engine)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,18 @@
 import pytest
 from dask.distributed import Client
 
+from cosima_cookbook import database
+
 @pytest.fixture(scope='module')
 def client():
     client = Client(processes=False, dashboard_address=None)
     yield client
     client.close()
+
+@pytest.fixture(scope='function')
+def session_db(tmpdir):
+    db = tmpdir.join('test.db')
+    s = database.create_session(str(db))
+    yield s, db
+
+    s.close()

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import sqlalchemy as sa
 from cosima_cookbook import database
 
 @pytest.fixture
@@ -20,9 +21,9 @@ def test_default(tmpdir):
     db = tmpdir.join('test.db')
     # override the NCI-specific default
     database.__DEFAULT_DB__ = str(db)
-    
+
     s = database.create_session()
-    
+
     assert(db.check())
 
 def test_env_var(db_env):
@@ -36,6 +37,71 @@ def test_arg_override(tmpdir, db_env):
     # is used rather than the environment variable
     db = tmpdir.join('test_other.db')
     s = database.create_session(str(db))
-    
+
     assert(not db_env.check())
     assert(db.check())
+
+def test_creation(session_db):
+    """Test that a database file is created with a session
+    when the session file doesn't exist."""
+
+    s, db = session_db
+    assert(db.check())
+
+    # we should be able to query against a table that exists
+    # with no error
+    s.execute('SELECT * FROM ncfiles')
+
+    # but not a non-existent table
+    with pytest.raises(sa.exc.OperationalError, match="no such table"):
+        s.execute('SELECT * FROM ncfiles_notfound')
+
+def test_reopen(tmpdir):
+    """Test that we can reopen a database of the correct version."""
+
+    db = tmpdir.join('test.db')
+    s = database.create_session(str(db))
+
+    s.close()
+    s = database.create_session(str(db))
+    s.close()
+
+def test_outdated(tmpdir):
+    """Test that we can't use an outdated database"""
+
+    db = tmpdir.join('test.db')
+    s = database.create_session(str(db))
+
+    # check that the current version matches that defined in the module
+    ver = s.execute('PRAGMA user_version').fetchone()[0]
+    assert(ver == database.__DB_VERSION__)
+
+    # reset version to one prior
+    s.execute('PRAGMA user_version={}'.format(database.__DB_VERSION__ - 1))
+    s.close()
+
+    # recreate the session
+    with pytest.raises(Exception, match='Incompatible database versions'):
+        s = database.create_session(str(db))
+
+def test_outdated_notmodified(tmpdir):
+    """Test that we don't try to modify an outdated database.
+    This includes adding tables that don't yet exist because
+    it's a previous version.
+    """
+
+    # set up an empty database with a previous version
+    db = tmpdir.join('test.db')
+    conn = sa.create_engine('sqlite:///' + str(db)).connect()
+    conn.execute('PRAGMA user_version={}'.format(database.__DB_VERSION__ - 1))
+    conn.close()
+
+    # try to create the session
+    # this should fail and not modify the existing database
+    with pytest.raises(Exception):
+        s = database.create_session(str(db))
+
+    # reopen the connection and ensure tables weren't created
+    conn = sa.create_engine('sqlite:///' + str(db)).connect()
+    with pytest.raises(sa.exc.OperationalError, match="no such table"):
+        conn.execute('SELECT * FROM ncfiles')

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -7,14 +7,6 @@ from cosima_cookbook import database
 from sqlalchemy import func
 
 @pytest.fixture
-def session_db(tmpdir):
-    db = tmpdir.join('test.db')
-    s = database.create_session(str(db))
-    yield s, db
-
-    s.close()
-
-@pytest.fixture
 def unreadable_dir(tmpdir):
     expt_path = tmpdir / "expt_dir"
     expt_path.mkdir()


### PR DESCRIPTION
We were telling the ORM to create all tables before the database version check, which means that if `create_session` was run on an outdated database, it would still get the new structure. We've added a few more tests around this, and moved the `create_all` call to happen after the version check.

This has a similar refactor to move the `session_db` fixture to `conftest.py` and will conflict with #187, but also fixes a bug that will be hit in that PR and should be merged before it.