### PR TITLE
Switch to using wildcard matches for keywords

### DIFF
--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -55,7 +55,7 @@ def get_experiments(session, experiment=True, keywords=None, all=False, **kwargs
         if isinstance(keywords, str):
             keywords = [ keywords ]
 
-        q = q.filter(*(NCExperiment.keywords == k for k in keywords))
+        q = q.filter(*(NCExperiment.keywords.like(k) for k in keywords))
 
     return pd.DataFrame(q)
 

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -24,7 +24,8 @@ def get_experiments(session, experiment=True, keywords=None, all=False, **kwargs
     within each experiment.
 
     Optionally one or more keywords can be specified, and only experiments with all the
-    specified keywords will be return.
+    specified keywords will be return. The keyword strings can utilise SQL wildcard
+    characters, "%" and "_", to match multiple keywords.
 
     All metadata fields will be returned if all=True, or individual metadata fields
     can be selected by passing field=True, where available fields are: 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -238,6 +238,13 @@ def test_get_experiments_with_keywords(session_db):
     )
     assert_frame_equal(r, df)
 
+    r = querying.get_experiments(session, keywords='access-om2%')
+    df = pd.DataFrame.from_dict(
+        {"experiment": ["keywords"], 
+         "ncfiles": [1]}
+    )
+    assert_frame_equal(r, df)
+
     # Test keyword in only one experiment
     r = querying.get_experiments(session, keywords='another-keyword')
     df = pd.DataFrame.from_dict(

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -223,6 +223,21 @@ def test_get_experiments_with_keywords(session_db):
     )
     assert_frame_equal(r, df)
 
+    # Test keyword common to both experiments using wildcard
+    r = querying.get_experiments(session, keywords='cos%')
+    df = pd.DataFrame.from_dict(
+        {"experiment": ["keywords", "keywords2"], 
+         "ncfiles": [1, 1]}
+    )
+    assert_frame_equal(r, df)
+    
+    r = querying.get_experiments(session, keywords='%-%')
+    df = pd.DataFrame.from_dict(
+        {"experiment": ["keywords", "keywords2"], 
+         "ncfiles": [1, 1]}
+    )
+    assert_frame_equal(r, df)
+
     # Test keyword in only one experiment
     r = querying.get_experiments(session, keywords='another-keyword')
     df = pd.DataFrame.from_dict(
@@ -260,5 +275,9 @@ def test_get_experiments_with_keywords(session_db):
     # Test passing only a non-existent keyword
     r = querying.get_experiments(session, keywords=['not-a-keyword'])
     df = pd.DataFrame()
-    
+    assert_frame_equal(r, df)
+
+    # Test passing only a non-existent wildcard keyword
+    r = querying.get_experiments(session, keywords=['z%'])
+    df = pd.DataFrame()
     assert_frame_equal(r, df)


### PR DESCRIPTION
Just a small update to use `like` in the keyword filter in `get_experiments` to allow for more flexibility when searching keywords.

Notably it would mean `access-om2-01` and `access-om2` could be matched with `access-om2%`