### PR TITLE
Make date range widget cftime compatible

### DIFF
--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from . import netcdf_utils
 from .database_utils import *
+from .date_utils import format_datetime
 
 logging.captureWarnings(True)
 
@@ -281,14 +282,8 @@ def update_timeinfo(f, ncfile):
             ncfile.frequency = 'static'
 
         # convert start/end times to timestamps
-        # strftime doesn't like years with fewer than 4 digits (pads with spaces
-        # instead of zeroes)...
-        def zeropad(s):
-            ss = s.lstrip()
-            return (len(s)-len(ss))*'0' + ss
-
-        ncfile.time_start = zeropad(ncfile.time_start.strftime('%Y-%m-%d %H:%M:%S'))
-        ncfile.time_end = zeropad(ncfile.time_end.strftime('%Y-%m-%d %H:%M:%S'))
+        ncfile.time_start = format_datetime(ncfile.time_start)
+        ncfile.time_end = format_datetime(ncfile.time_end)
 
 def index_file(ncfile_name, experiment):
     """Index a single netCDF file within an experiment by retrieving all variables, their dimensions

--- a/cosima_cookbook/date_utils.py
+++ b/cosima_cookbook/date_utils.py
@@ -20,7 +20,7 @@ import cftime
 from cftime import num2date, date2num
 import numpy as np
 import xarray as xr
-from xarray.coding.cftimeindex import _parse_iso8601_without_reso
+from xarray.coding.cftime_offsets import to_cftime_datetime
 
 rebase_attr = '_rebased_units'
 rebase_shift_attr = '_rebased_shift'
@@ -199,13 +199,9 @@ def format_datetime(datetime, format=datetimeformat):
     storage in SQL database. Hard code the length as some datetime
     objects don't space pad when formatted! 
     """
-    def zeropad(s):
-        ss = s.lstrip()
-        return (19-len(ss))*'0' + ss
-    
-    return zeropad(datetime.strftime(format))
+    return '{:0>19}'.format(datetime.strftime(format).lstrip())
 
-def parse_datetime(datetimestring, datetype=cftime.DatetimeProlepticGregorian):
+def parse_datetime(datetimestring, calendar="proleptic_gregorian"):
     """
     Standard method to convert datetime obkects stored as strings in SQL database 
     back into cftime.datetime objects
@@ -218,4 +214,4 @@ def parse_datetime(datetimestring, datetype=cftime.DatetimeProlepticGregorian):
 
     # Note: uses non-public xarray method that may change or be deleted
     # in the future
-    return _parse_iso8601_without_reso(datetype, datetimestring)
+    return to_cftime_datetime(datetimestring, calendar)

--- a/cosima_cookbook/date_utils.py
+++ b/cosima_cookbook/date_utils.py
@@ -14,15 +14,20 @@ limitations under the License.
 
 from __future__ import print_function
 
-import xarray as xr
+import datetime
+
+import cftime
 from cftime import num2date, date2num
 import numpy as np
-import datetime
+import xarray as xr
+from xarray.coding.cftimeindex import _parse_iso8601_without_reso
 
 rebase_attr = '_rebased_units'
 rebase_shift_attr = '_rebased_shift'
 bounds = 'bounds'
 boundsvar = 'bounds_var'
+
+datetimeformat = '%Y-%m-%d %H:%M:%S'
 
 # Code adapted from https://github.com/spencerahill/aospy/issues/212
 
@@ -187,3 +192,30 @@ def shift_time(ds):
     Apply time shift to un-decoded time axis, to align datasets and 
     """
     pass
+
+def format_datetime(datetime, format=datetimeformat):
+    """
+    Standard method to convert cftime.datetime objects to strings for
+    storage in SQL database. Hard code the length as some datetime
+    objects don't space pad when formatted! 
+    """
+    def zeropad(s):
+        ss = s.lstrip()
+        return (19-len(ss))*'0' + ss
+    
+    return zeropad(datetime.strftime(format))
+
+def parse_datetime(datetimestring, datetype=cftime.DatetimeProlepticGregorian):
+    """
+    Standard method to convert datetime obkects stored as strings in SQL database 
+    back into cftime.datetime objects
+    """
+    # xarray supports parsing dates strings to cftime.datetime objects, but 
+    # requires ISO-8601 format (https://en.wikipedia.org/wiki/ISO_8601).
+    # Convert string to ISO-8601 before parsing by adding separator
+    # between date and time elements
+    datetimestring = datetimestring[:10] + 'T' + datetimestring[11:]
+
+    # Note: uses non-public xarray method that may change or be deleted
+    # in the future
+    return _parse_iso8601_without_reso(datetype, datetimestring)

--- a/cosima_cookbook/explore.py
+++ b/cosima_cookbook/explore.py
@@ -8,18 +8,18 @@ import pandas as pd
 from sqlalchemy import func
 import xarray as xr
 
-import cosima_cookbook
-import cosima_cookbook as cc
-from . import database, querying 
+from . import database, querying
 from .database import CFVariable, NCFile, NCExperiment, NCVar
 from .date_utils import format_datetime, parse_datetime
+
 
 def return_value_or_empty(value):
     """Return value if not None, otherwise empty"""
     if value is None:
-        return ''
+        return ""
     else:
         return value
+
 
 class DatabaseExtension:
 
@@ -29,7 +29,7 @@ class DatabaseExtension:
     keywords = None
     variables = None
     expt_variable_map = None
-    
+
     def __init__(self, session=None, experiments=None):
         """
         Generate and store derived information based on queries to the back end
@@ -47,10 +47,14 @@ class DatabaseExtension:
             self.experiments = self.allexperiments
         else:
             if isinstance(experiments, str):
-                experiments = [experiments,]
+                experiments = [
+                    experiments,
+                ]
             # Subset experiment column from dataframe, and don't pass as a simple list
             # otherwise index is not correctly named
-            self.experiments = self.allexperiments[self.allexperiments.experiment.isin(experiments)]
+            self.experiments = self.allexperiments[
+                self.allexperiments.experiment.isin(experiments)
+            ]
 
         self.keywords = sorted(querying.get_keywords(session), key=str.casefold)
         self.expt_variable_map = self.experiment_variable_map()
@@ -58,47 +62,63 @@ class DatabaseExtension:
 
     def experiment_variable_map(self):
         """
-        Make a pandas table with experiment as the index and columns of name, long_name, 
-        coordinate flag, restart flag and model type.
+        Make a pandas table with experiment as the index and columns of name,
+        long_name, coordinate flag, restart flag and model type.
         """
-        allvars = pd.concat([self.get_variables(expt) for expt in self.experiments.experiment], 
-                            keys=self.experiments.experiment)
+        allvars = pd.concat(
+            [self.get_variables(expt) for expt in self.experiments.experiment],
+            keys=self.experiments.experiment,
+        )
 
         # Create a new column to flag if variable is from a restart directory
-        allvars['restart'] = allvars.ncfile.str.contains('restart')
+        allvars["restart"] = allvars.ncfile.str.contains("restart")
 
         # Create a new column to characterise model type
-        allvars['model'] = ''
+        allvars["model"] = ""
 
         # There is no metadata in the files or database that will let us know which
         # model produced the output, so use a heuristic that assumes if the data
-        # resides in a directory that is named for a model type it is output from 
-        # that model. Doesn't use os.path.sep as it is never envisaged this will be used 
+        # resides in a directory that is named for a model type it is output from
+        # that model. Doesn't use os.path.sep as it is never envisaged this will be used
         # outside of a posix system
-        allvars.loc[(allvars.ncfile.str.contains(r'\bocean\b')  |
-                     allvars.ncfile.str.contains(r'\bocn\b')), 'model'] = 'ocean'
-        allvars.loc[(allvars.ncfile.str.contains(r'\batmosphere\b') | 
-                     allvars.ncfile.str.contains(r'\batm\b')), 'model'] = 'atmosphere'
-        allvars.loc[allvars.ncfile.str.contains(r'\bice\b'), 'model'] = 'ice'
+        allvars.loc[
+            (
+                allvars.ncfile.str.contains(r"\bocean\b")
+                | allvars.ncfile.str.contains(r"\bocn\b")
+            ),
+            "model",
+        ] = "ocean"
+        allvars.loc[
+            (
+                allvars.ncfile.str.contains(r"\batmosphere\b")
+                | allvars.ncfile.str.contains(r"\batm\b")
+            ),
+            "model",
+        ] = "atmosphere"
+        allvars.loc[allvars.ncfile.str.contains(r"\bice\b"), "model"] = "ice"
 
-        allvars['model'] = allvars['model'].astype('category')
+        allvars["model"] = allvars["model"].astype("category")
 
         # Create a new column to flag if variable has units which match a number of criteria
         # that indicated it is a coordinate
-        allvars = allvars.assign(coordinate=(allvars.units.str.contains('degrees', na=False) |
-                                             allvars.units.str.contains('since', na=False)   |
-                                             allvars.units.str.match('^radians$', na=False)  |
-                                             allvars.units.str.startswith('days', na=False)))  # legit units: %/day, day of year
+        allvars = allvars.assign(
+            coordinate=(
+                allvars.units.str.contains("degrees", na=False)
+                | allvars.units.str.contains("since", na=False)
+                | allvars.units.str.match("^radians$", na=False)
+                | allvars.units.str.startswith("days", na=False)
+            )
+        )  # legit units: %/day, day of year
 
-        return allvars[['name', 'long_name', 'model', 'restart', 'coordinate']]
+        return allvars[["name", "long_name", "model", "restart", "coordinate"]]
 
     def unique_variable_list(self):
         """
-        Extract a list of all unique variable name/long_name/model/restart/coordinate 
+        Extract a list of all unique variable name/long_name/model/restart/coordinate
         combinations from the experiment keyword map
         """
         return self.expt_variable_map.reset_index(drop=True).drop_duplicates()
-        
+
     def keyword_filter(self, keywords):
         """
         Return a list of experiments matching *all* of the supplied keywords
@@ -115,15 +135,19 @@ class DatabaseExtension:
         expts = []
         for v in variables:
             expts.append(
-                set(self.expt_variable_map[self.expt_variable_map.name == v].reset_index()['experiment'])
+                set(
+                    self.expt_variable_map[
+                        self.expt_variable_map.name == v
+                    ].reset_index()["experiment"]
+                )
             )
         return set.intersection(*expts)
-    
+
     def get_experiment(self, experiment):
         """
         Convenience routine to return the full entry given an experiment name
         """
-        return self.experiments[self.experiments['experiment'] == experiment]
+        return self.experiments[self.experiments["experiment"] == experiment]
 
     # Return more metadata than get_variables from cosima-cookbook
     def get_variables(self, experiment, frequency=None):
@@ -132,42 +156,44 @@ class DatabaseExtension:
         a given diagnostic frequency.
         """
 
-        q = (self.session
-            .query(CFVariable.name,
-                    CFVariable.long_name,
-                    CFVariable.standard_name,
-                    CFVariable.units,
-                    NCFile.frequency,
-                    NCFile.ncfile,
-                    func.count(NCFile.ncfile).label('# ncfiles'),
-                    func.min(NCFile.time_start).label('time_start'),
-                    func.max(NCFile.time_end).label('time_end'))
+        q = (
+            self.session.query(
+                CFVariable.name,
+                CFVariable.long_name,
+                CFVariable.standard_name,
+                CFVariable.units,
+                NCFile.frequency,
+                NCFile.ncfile,
+                func.count(NCFile.ncfile).label("# ncfiles"),
+                func.min(NCFile.time_start).label("time_start"),
+                func.max(NCFile.time_end).label("time_end"),
+            )
             .join(NCFile.experiment)
             .join(NCFile.ncvars)
             .join(NCVar.variable)
             .filter(NCExperiment.experiment == experiment)
-            .order_by(NCFile.frequency,
-                    CFVariable.name,
-                    NCFile.time_start,
-                    NCFile.ncfile)
-            .group_by(CFVariable.name, NCFile.frequency))
+            .order_by(
+                NCFile.frequency, CFVariable.name, NCFile.time_start, NCFile.ncfile
+            )
+            .group_by(CFVariable.name, NCFile.frequency)
+        )
 
         if frequency is not None:
             q = q.filter(NCFile.frequency == frequency)
 
         return pd.DataFrame(q)
-    
+
 
 class VariableSelector(VBox):
     """
     Combo widget based on a Select box with a search panel above to live
     filter variables to Select. When a variable is selected the long name
-    attribute is displayed under the select box. There are also two 
+    attribute is displayed under the select box. There are also two
     checkboxes which hide coordinates and restart variables.
 
     Note that a dict is used to populate the Select widget, so the visible
-    value is the variable name and is accessed via the label attribute, 
-    and the long name via the value attribute. 
+    value is the variable name and is accessed via the label attribute,
+    and the long name via the value attribute.
     """
 
     variables = None
@@ -179,13 +205,17 @@ class VariableSelector(VBox):
         specified
         """
         self._make_widgets(rows)
-        super().__init__(children=[self.model,
-                                   self.search,
-                                   self.selector,
-                                   self.info,
-                                   self.filter_coords,
-                                   self.filter_restarts], 
-                                   **kwargs)
+        super().__init__(
+            children=[
+                self.model,
+                self.search,
+                self.selector,
+                self.info,
+                self.filter_coords,
+                self.filter_restarts,
+            ],
+            **kwargs
+        )
         self.set_variables(variables)
         self._set_info()
         self._set_observes()
@@ -198,46 +228,40 @@ class VariableSelector(VBox):
         # Experiment selector element
         self.model = Dropdown(
             options=(),
-            layout={'padding': '0px 5px', 'width': 'initial'},
-            description='',
+            layout={"padding": "0px 5px", "width": "initial"},
+            description="",
         )
         # Variable search
         self.search = Text(
-            placeholder='Search: start typing', 
-            layout={'padding': '0px 5px', 'width': 'auto', 'overflow-x': 'scroll'},
+            placeholder="Search: start typing",
+            layout={"padding": "0px 5px", "width": "auto", "overflow-x": "scroll"},
         )
         # Variable selection box
         self.selector = Select(
-            options=(), #sorted(self.variables.name, key=str.casefold),
+            options=(),  # sorted(self.variables.name, key=str.casefold),
             rows=rows,
-            layout=self.search.layout
+            layout=self.search.layout,
         )
         # Variable info
-        self.info = HTML(
-            layout=self.search.layout
-        )
+        self.info = HTML(layout=self.search.layout)
         # Variable filtering elements
         self.filter_coords = Checkbox(
-            value=True,
-            indent=False,
-            description='Hide coordinates',
+            value=True, indent=False, description="Hide coordinates",
         )
         self.filter_restarts = Checkbox(
-            value=True,
-            indent=False,
-            description='Hide restarts',
+            value=True, indent=False, description="Hide restarts",
         )
 
     def _set_observes(self):
         """
         Set event handlers
         """
-        self.filter_coords.observe(self._filter_eventhandler, names='value')
-        self.filter_restarts.observe(self._filter_eventhandler, names='value')
+        self.filter_coords.observe(self._filter_eventhandler, names="value")
+        self.filter_restarts.observe(self._filter_eventhandler, names="value")
 
-        self.model.observe(self._model_eventhandler, names='value')
-        self.search.observe(self._search_eventhandler, names='value')
-        self.selector.observe(self._selector_eventhandler, names='value')
+        self.model.observe(self._model_eventhandler, names="value")
+        self.search.observe(self._search_eventhandler, names="value")
+        self.selector.observe(self._selector_eventhandler, names="value")
 
     def set_variables(self, variables):
         """
@@ -259,13 +283,15 @@ class VariableSelector(VBox):
         for easy filtering
         """
         # Populate model selector. Note label and value differ
-        options = {'All models': ''}
+        options = {"All models": ""}
         for model in variables.model.cat.categories.values:
             options["{} only".format(model.capitalize())] = model
         self.model.options = options
 
         # Populate variable selector
-        self.selector.options = dict(variables.sort_values(['name'])[['name','long_name']].values)
+        self.selector.options = dict(
+            variables.sort_values(["name"])[["name", "long_name"]].values
+        )
 
     def _reset_filters(self):
         """
@@ -276,7 +302,7 @@ class VariableSelector(VBox):
 
     def _model_eventhandler(self, event=None):
         """
-        Filter by model 
+        Filter by model
         """
         model = self.model.value
 
@@ -288,35 +314,35 @@ class VariableSelector(VBox):
         """
         Called when filter button pushed
         """
-        self._filter_variables(self.filter_coords.value,
-                               self.filter_restarts.value,
-                               self.model.value)
+        self._filter_variables(
+            self.filter_coords.value, self.filter_restarts.value, self.model.value
+        )
 
-    def _filter_variables(self, coords=True, restarts=True, model=''):
+    def _filter_variables(self, coords=True, restarts=True, model=""):
         """
         Optionally hide some variables
         """
         # Set up a mask with all true values
-        mask = self.variables.name.ne('')
+        mask = self.variables.name.ne("")
 
         # Filter for matching models
-        if model != '':
-            mask = mask & (self.variables['model'] == model)
+        if model != "":
+            mask = mask & (self.variables["model"] == model)
 
         # Conditionally filter out restarts and coordinates
         if coords:
-            mask = mask & ~self.variables['coordinate']
+            mask = mask & ~self.variables["coordinate"]
         if restarts:
-            mask = mask & ~self.variables['restart']
+            mask = mask & ~self.variables["restart"]
 
         # Mask out hidden variables
-        self.variables['visible'] = mask
+        self.variables["visible"] = mask
 
         # Update the variable selector
         self._update_selector(self.variables[self.variables.visible])
 
         # Reset the search
-        self.search.value = ''
+        self.search.value = ""
         self.selector.value = None
 
     def _search_eventhandler(self, event=None):
@@ -327,31 +353,33 @@ class VariableSelector(VBox):
         search_term = self.search.value
 
         variables = self.variables[self.variables.visible]
-        if search_term is not None or search_term != '':
+        if search_term is not None or search_term != "":
             try:
-                variables = variables[variables.name.str.contains(search_term, na=False) |
-                                    variables.long_name.str.contains(search_term, na=False) ]
+                variables = variables[
+                    variables.name.str.contains(search_term, na=False)
+                    | variables.long_name.str.contains(search_term, na=False)
+                ]
             except:
-                print('Illegal character in search!')
+                print("Illegal character in search!")
                 search_term = self.search.value
 
         self._update_selector(variables)
-    
+
     def _selector_eventhandler(self, event=None):
         """
         Update variable info when variable selected
         """
         self._set_info(self.selector.value)
-    
+
     def _set_info(self, long_name=None):
         """
-        Set long name info widget 
+        Set long name info widget
         """
-        if long_name is None or long_name == '':
-            long_name = '&nbsp;'
-        style = '<style>p{word-wrap: break-word}</style>' 
-        self.info.value = style + '<p>{long_name}</p>'.format(long_name=long_name)
-    
+        if long_name is None or long_name == "":
+            long_name = "&nbsp;"
+        style = "<style>p{word-wrap: break-word}</style>"
+        self.info.value = style + "<p>{long_name}</p>".format(long_name=long_name)
+
     def delete(self, variable_names=None):
         """
         Remove variables
@@ -361,19 +389,23 @@ class VariableSelector(VBox):
             if self.selector.label is None:
                 return None
             else:
-                variable_names = [ self.selector.label, ]
+                variable_names = [
+                    self.selector.label,
+                ]
 
         if isinstance(variable_names, str):
-            variable_names = [ variable_names, ]
+            variable_names = [
+                variable_names,
+            ]
 
-        mask = self.variables['name'].isin(variable_names)
+        mask = self.variables["name"].isin(variable_names)
         deleted = self.variables[mask]
 
         # Delete variables
         self.variables = self.variables[~mask]
 
-        # Update selector. Use search eventhandler so the selector preserves any 
-        # current search term. It is annoying to have that reset and type in again 
+        # Update selector. Use search eventhandler so the selector preserves any
+        # current search term. It is annoying to have that reset and type in again
         # if multiple variables are to be added
         self._search_eventhandler()
 
@@ -395,6 +427,7 @@ class VariableSelector(VBox):
         """
         return self.selector.label
 
+
 class VariableSelectorInfo(VariableSelector):
     """
     Subclass of VariableSelector to display more info in a separate widget
@@ -404,16 +437,16 @@ class VariableSelectorInfo(VariableSelector):
 
         super(VariableSelectorInfo, self).__init__(variables, rows, **kwargs)
 
-        # Requires two widgets passed in as an argument. An html box where 
+        # Requires two widgets passed in as an argument. An html box where
         # extended meta-data will be displayed, and a date range widget for
         # selecting start and end times to load
         self.daterange = daterange
         self.frequency = frequency
 
-        # Set event handlers. Don't use _set_observes method: don't want 
+        # Set event handlers. Don't use _set_observes method: don't want
         # it called when super init invoked
-        self.selector.observe(self._var_eventhandler, names='value')
-        self.frequency.observe(self._frequency_eventhandler, names='value')
+        self.selector.observe(self._var_eventhandler, names="value")
+        self.frequency.observe(self._frequency_eventhandler, names="value")
 
         # Set default filtering
         self._filter_variables()
@@ -429,10 +462,10 @@ class VariableSelectorInfo(VariableSelector):
         Populate the variable loading selectors widgets for daterange
         and frequency given a variable name
         """
-        variable = self.variables.loc[self.variables['name'] == variable_name]
+        variable = self.variables.loc[self.variables["name"] == variable_name]
 
         # Initialise daterange widget
-        self.daterange.options = ['0000','0000']
+        self.daterange.options = ["0000", "0000"]
         self.daterange.disabled = True
 
         self.frequency.options = []
@@ -440,7 +473,7 @@ class VariableSelectorInfo(VariableSelector):
 
         if len(variable) == 0:
             return
-        
+
         self.frequency.options = variable.frequency
         self.frequency.index = 0
         self.frequency.disabled = False
@@ -456,31 +489,36 @@ class VariableSelectorInfo(VariableSelector):
         When frequency selector is changed update daterange slider
         """
         # Find the matching variable in our list
-        variable = self.variables.loc[(self.variables['name'] == variable_name) & 
-                                      (self.variables['frequency'] == frequency)]
+        variable = self.variables.loc[
+            (self.variables["name"] == variable_name)
+            & (self.variables["frequency"] == frequency)
+        ]
         try:
             # Populate daterange widget if variable contains necessary information
-            # Convert human readable frequency to pandas compatigle frequency string 
-            freq = re.sub(r'^(\d+) (\w)(\w+)', 
-                          r'\1\2', 
-                          str(variable.frequency.values[0]).upper())
-            # import pdb; pdb.set_trace()
-            dates = xr.cftime_range(parse_datetime(variable.time_start.values[0]), 
-                                    parse_datetime(variable.time_end.values[0]), 
-                                    freq=freq)
-            self.daterange.options = [(i.strftime('%Y/%m/%d'), i) for i in dates]                
+            # Convert human readable frequency to pandas compatigle frequency string
+            freq = re.sub(
+                r"^(\d+) (\w)(\w+)", r"\1\2", str(variable.frequency.values[0]).upper()
+            )
+            dates = xr.cftime_range(
+                parse_datetime(variable.time_start.values[0]),
+                parse_datetime(variable.time_end.values[0]),
+                freq=freq,
+            )
+            self.daterange.options = [(i.strftime("%Y/%m/%d"), i) for i in dates]
             self.daterange.value = (dates[0], dates[-1])
         except:
             pass
         finally:
             self.daterange.disabled = False
 
+
 class VariableSelectFilter(HBox):
     """
-    Combo widget which contains a VariableSelector from which variables can 
+    Combo widget which contains a VariableSelector from which variables can
     be transferred to another Select Widget to specify which variables should
     be used to filter experiments
     """
+
     variables = pd.DataFrame()
 
     def __init__(self, selvariables, **kwargs):
@@ -491,8 +529,9 @@ class VariableSelectFilter(HBox):
         """
         self._make_widgets(selvariables, **kwargs)
 
-        super().__init__(children=[self.selector, self.button_box, self.filter_box], 
-                         **kwargs)
+        super().__init__(
+            children=[self.selector, self.button_box, self.filter_box], **kwargs
+        )
 
         self._set_observes()
 
@@ -500,32 +539,31 @@ class VariableSelectFilter(HBox):
         """
         Instantiate all widgets
         """
-        layout = {'padding': '0px 5px'}
+        layout = {"padding": "0px 5px"}
         # Variable selector combo-widget
         self.selector = VariableSelector(selvariables, **kwargs)
         # Button to add variable from selector to selected
         self.var_filter_add = Button(
-            tooltip='Add selected variable to filter',
-            icon='angle-double-right',
-            layout={'width': 'auto'},
+            tooltip="Add selected variable to filter",
+            icon="angle-double-right",
+            layout={"width": "auto"},
         )
         # Button to add variable from selector to selected
         self.var_filter_sub = Button(
-            tooltip='Remove selected variable from filter',
-            icon='angle-double-left',
-            layout={'width': 'auto'},
+            tooltip="Remove selected variable from filter",
+            icon="angle-double-left",
+            layout={"width": "auto"},
         )
-        self.button_box = VBox([self.var_filter_add, self.var_filter_sub],
-                               layout={'padding': '100px 5px', 'height': '100%'})
+        self.button_box = VBox(
+            [self.var_filter_add, self.var_filter_sub],
+            layout={"padding": "100px 5px", "height": "100%"},
+        )
         # Selected variables for filtering with header widget
-        self.var_filter_label = HTML('Filter variables:', layout=layout)
-        self.var_filter_selected = Select(
-            options=[],
-            rows=10,
-            layout=layout,
+        self.var_filter_label = HTML("Filter variables:", layout=layout)
+        self.var_filter_selected = Select(options=[], rows=10, layout=layout,)
+        self.filter_box = VBox(
+            [self.var_filter_label, self.var_filter_selected], layout=layout
         )
-        self.filter_box = VBox([self.var_filter_label, 
-                                self.var_filter_selected], layout=layout)
 
     def _set_observes(self):
         """
@@ -538,7 +576,9 @@ class VariableSelectFilter(HBox):
         """
         Update filtered variables
         """
-        self.var_filter_selected.options = dict(self.variables.sort_values(['name'])[['name','long_name']].values)
+        self.var_filter_selected.options = dict(
+            self.variables.sort_values(["name"])[["name", "long_name"]].values
+        )
 
     def _add_var_to_selected(self, button):
         """
@@ -573,9 +613,11 @@ class VariableSelectFilter(HBox):
                 variable_names = [self.var_filter_selected.label]
 
         if isinstance(variable_names, str):
-            variable_names = [ variable_names, ]
+            variable_names = [
+                variable_names,
+            ]
 
-        mask = self.variables['name'].isin(variable_names)
+        mask = self.variables["name"].isin(variable_names)
         deleted = self.variables[mask]
 
         # Delete variables
@@ -592,10 +634,11 @@ class VariableSelectFilter(HBox):
         """
         return self.var_filter_selected.options
 
+
 class DatabaseExplorer(VBox):
     """
     Combo widget based on a select box containing all experiments in
-    specified database. 
+    specified database.
     """
 
     session = None
@@ -603,55 +646,55 @@ class DatabaseExplorer(VBox):
     ee = None
 
     def __init__(self, session=None, de=None):
-        if de is None: 
+        if de is None:
             de = DatabaseExtension(session)
         self.de = de
 
         self._make_widgets()
 
         # Call super init and pass widgets as children
-        super().__init__(children=[self.header,
-                                   self.selectors,
-                                   self.expt_info,
-                                   self.expt_explorer])
+        super().__init__(
+            children=[self.header, self.selectors, self.expt_info, self.expt_explorer]
+        )
 
         self._set_handlers()
 
     def _make_widgets(self):
 
-        box_layout = Layout(padding='10px', width='auto', border= '0px solid black')
+        box_layout = Layout(padding="10px", width="auto", border="0px solid black")
 
-        style = '<style>p { line-height: 1.4; margin-bottom: 10px }</style>'
+        style = "<style>p { line-height: 1.4; margin-bottom: 10px }</style>"
 
         # Gui header
         self.header = HTML(
-            value = style + """
+            value=style
+            + """
             <h3>Database Explorer</h3>
 
             <p>Select an experiemt to show more detailed information where available.
-            With an experiment selected push 'Load Experiment' to open an Experiment 
+            With an experiment selected push 'Load Experiment' to open an Experiment
             Explorer gui.</p>
 
-            <p>The list of experiments can be filtered by keywords and/or variables. 
+            <p>The list of experiments can be filtered by keywords and/or variables.
             Multiple keywords can be selected using alt/option/ctrl (system dependent)
-            or the shift modifier when selecting. To filter by variables select a 
-            variable and add it to the "Filter variables" box using the ">>" button, 
-            and vice-versa to remove variables from the filter. Push the 'Filter' 
+            or the shift modifier when selecting. To filter by variables select a
+            variable and add it to the "Filter variables" box using the ">>" button,
+            and vice-versa to remove variables from the filter. Push the 'Filter'
             button to show only matching experiments.</p>
 
-            <p>The ExperimentExplorer element is accessible as the <tt>ee</tt> attribute
-            of the DatabaseExplorer object</p>
+            <p>When the ExperimentExplorer element loads data it is accessible as the
+            <tt>.data</tt> attribute of the DatabaseExplorer object</p>
             """,
-            description='',
-            layout={'width': '60%'},
-        ) 
+            description="",
+            layout={"width": "60%"},
+        )
 
         # Experiment selector box
         self.expt_selector = Select(
             options=sorted(self.de.experiments.experiment, key=str.casefold),
             rows=24,
-            layout={'padding': '0px 5px', 'width': 'auto'},
-            disabled=False
+            layout={"padding": "0px 5px", "width": "auto"},
+            disabled=False,
         )
 
         # Keyword filtering element is a Multiple selection box
@@ -659,71 +702,76 @@ class DatabaseExplorer(VBox):
         self.filter_widget = SelectMultiple(
             rows=15,
             options=sorted(self.de.keywords, key=str.casefold),
-            layout={'flex': '0 0 100%'},
+            layout={"flex": "0 0 100%"},
         )
         # Reset keywords button
         self.clear_keywords_button = Button(
-            description='Clear',
-            layout={'width': '20%', 'align': 'center'},
-            tooltip='Click to clear selected keywords'
+            description="Clear",
+            layout={"width": "20%", "align": "center"},
+            tooltip="Click to clear selected keywords",
         )
-        self.keyword_box = VBox([self.filter_widget, 
-                                 self.clear_keywords_button],
-                                 layout={'flex': '0 0 40%'})
+        self.keyword_box = VBox(
+            [self.filter_widget, self.clear_keywords_button], layout={"flex": "0 0 40%"}
+        )
 
         # Filtering button
         self.filter_button = Button(
-            description='Filter',
+            description="Filter",
             # layout={'width': '50%', 'align': 'center'},
-            tooltip='Click to filter experiments',
+            tooltip="Click to filter experiments",
         )
 
         # Variable filter selector combo widget
-        self.var_filter = VariableSelectFilter(self.de.variables, 
-                                               layout={'flex': '0 0 40%'})
+        self.var_filter = VariableSelectFilter(
+            self.de.variables, layout={"flex": "0 0 40%"}
+        )
 
         # Tab box to contain keyword and variable filters
-        self.filter_tabs = Tab(title='Filter', children=[self.keyword_box, 
-                                                         self.var_filter])
-        self.filter_tabs.set_title(0, 'Keyword')
-        self.filter_tabs.set_title(1, 'Variable')
+        self.filter_tabs = Tab(
+            title="Filter", children=[self.keyword_box, self.var_filter]
+        )
+        self.filter_tabs.set_title(0, "Keyword")
+        self.filter_tabs.set_title(1, "Variable")
 
         self.load_button = Button(
-            description='Load Experiment',
+            description="Load Experiment",
             disabled=False,
-            layout={'width': '50%', },
-            tooltip='Click to load experiment'
+            layout={"width": "50%",},
+            tooltip="Click to load experiment",
         )
 
         # Experiment information panel
         self.expt_info = HTML(
-            value='',
-            description='',
-            layout={'width': '80%', 'align': 'center'},
+            value="", description="", layout={"width": "80%", "align": "center"},
         )
 
         # Experiment explorer box
         self.expt_explorer = HBox()
 
         # Some box layout nonsense to organise widgets in space
-        self.selectors = HBox([
-                            VBox([Label(value="Experiments:"), 
-                                self.expt_selector,
-                                self.load_button,
-                                ],
-                                layout={'padding': '0px 5px', 'flex': '0 0 30%'}),
-                            VBox([Label(value="Filter by:"), 
-                                self.filter_tabs,
-                                self.filter_button],
-                                layout={'padding': '0px 10px', 'flex': '0 0 65%'}),
-                                #layout=box_layout,),
-                        ])
+        self.selectors = HBox(
+            [
+                VBox(
+                    [
+                        Label(value="Experiments:"),
+                        self.expt_selector,
+                        self.load_button,
+                    ],
+                    layout={"padding": "0px 5px", "flex": "0 0 30%"},
+                ),
+                VBox(
+                    [Label(value="Filter by:"), self.filter_tabs, self.filter_button],
+                    layout={"padding": "0px 10px", "flex": "0 0 65%"},
+                ),
+                # layout=box_layout,),
+            ]
+        )
 
     def _set_handlers(self):
         """
         Define routines to handle button clicks and experiment selection
         """
-        self.expt_selector.observe(self._expt_eventhandler, names='value')
+        self.expt_selector.observe(self._expt_eventhandler, names="value")
         self.load_button.on_click(self._load_experiment)
         self.filter_button.on_click(self._filter_experiments)
         self.clear_keywords_button.on_click(self._clear_keywords)
@@ -755,7 +803,7 @@ class DatabaseExplorer(VBox):
         """
         expt = self.de.experiments[self.de.experiments.experiment == experiment_name]
 
-        style ="""
+        style = """
         <style>
             body  { font: normal 8px Verdana, Arial, sans-serif; }
             table { padding: 10px; border-spacing: 0px 0px; background-color: #fff;" }
@@ -763,7 +811,9 @@ class DatabaseExplorer(VBox):
             p     { line-height: 1.2; margin-top: 5px }
         </style>
         """
-        self.expt_info.value = style + """
+        self.expt_info.value = (
+            style
+            + """
         <table>
         <tr><td><b>Experiment:</b></td> <td>{experiment}</td></tr>
         <tr><td style="vertical-align:top;"><b>Description:</b></td> <td><p>{description}</p></td></tr>
@@ -772,11 +822,22 @@ class DatabaseExplorer(VBox):
         <tr><td><b>No. files:</b></td> <td>{ncfiles}</td></tr>
         <tr><td><b>Created:</b></td> <td>{created}</td></tr>
         </table>
-        """.format(experiment=experiment_name, 
-                    **{field: return_value_or_empty(expt[field].values[0])
-                       for field in ['description', 'notes', 'contact', 
-                                     'email', 'ncfiles', 'created']})
-        
+        """.format(
+                experiment=experiment_name,
+                **{
+                    field: return_value_or_empty(expt[field].values[0])
+                    for field in [
+                        "description",
+                        "notes",
+                        "contact",
+                        "email",
+                        "ncfiles",
+                        "created",
+                    ]
+                }
+            )
+        )
+
     def _filter_experiments(self, b):
         """
         Filter experiment list by keywords and variable
@@ -798,24 +859,27 @@ class DatabaseExplorer(VBox):
         Open an Experiment Explorer UI with selected experiment
         """
         if self.expt_selector.value is not None:
-            self.ee = ExperimentExplorer(session=self.session, 
-                                         experiment=self.expt_selector.value)
+            self.ee = ExperimentExplorer(
+                session=self.session, experiment=self.expt_selector.value
+            )
             self.expt_explorer.children = [self.ee]
 
+    @property
     def data(self):
         """
-        Return xarray DataArray if one has been loaded in ExperimentExplorer 
+        Return xarray DataArray if one has been loaded in ExperimentExplorer
         """
         if self.ee is None:
-            print('Cannot return data if no experiment has been loaded')
+            print("Cannot return data if no experiment has been loaded")
             return None
 
-        return self.ee.data()
+        return self.ee.data
+
 
 class ExperimentExplorer(VBox):
 
     session = None
-    loaded_data = None
+    _loaded_data = None
     experiment_name = None
     variables = []
 
@@ -826,7 +890,7 @@ class ExperimentExplorer(VBox):
 
         if experiment is None:
             # Have to pass an experiment to DatabaseExtension so that
-            # it only creates a variable/keyword map for a single 
+            # it only creates a variable/keyword map for a single
             # experiment
             expts = querying.get_experiments(self.session, all=True)
             experiment = expts.iloc[0].experiment
@@ -837,11 +901,15 @@ class ExperimentExplorer(VBox):
         self._make_widgets()
 
         # Call super init and pass widgets as children
-        super().__init__(children=[self.header,
-                                   self.expt_selector,
-                                   self.centre_pane,
-                                   self.load_button,
-                                   self.data_box])
+        super().__init__(
+            children=[
+                self.header,
+                self.expt_selector,
+                self.centre_pane,
+                self.load_button,
+                self.data_box,
+            ]
+        )
 
         self._load_experiment(self.experiment_name)
         self._set_handlers()
@@ -851,68 +919,66 @@ class ExperimentExplorer(VBox):
         self.header = HTML(
             value="""
             <h3>Experiment Explorer</h3>
-            
+
             <p>Select a variable from the list to display metadata information.
             Where appropriate select a date range. Pressing the <b>Load</b> button
             will read the data into an <tt>xarray DataArray</tt> using the COSIMA Cookook. 
             The command used is output and can be copied and modified as required.</p>
 
-            <p>The loaded DataArray is accessible as the <tt>data</tt> attribute 
+            <p>The loaded DataArray is accessible as the <tt>.data</tt> attribute 
             of the ExperimentExplorer object.</p> 
-            
+
             <p>The selected experiment can be changed to any experiment present
             in the current database session.</p>
             """,
-            description='',
+            description="",
         )
         # Experiment selector element
         self.expt_selector = Dropdown(
             options=sorted(self.de.allexperiments.experiment, key=str.casefold),
             value=self.experiment_name,
-            description='',
-            layout={'width': '40%'}
+            description="",
+            layout={"width": "40%"},
         )
         # Date selection widget
-        self.frequency = Dropdown(
-            options=(),
-            description='Frequency',
-            disabled=True,
-        )
+        self.frequency = Dropdown(options=(), description="Frequency", disabled=True,)
         # Date selection widget
         self.daterange = SelectionRangeSlider(
-            options=['0000','0001'],
-            index=(0,1),
-            description='Date range',
-            layout={'width': '80%'},
-            disabled=True
+            options=["0000", "0001"],
+            index=(0, 1),
+            description="Date range",
+            layout={"width": "80%"},
+            disabled=True,
         )
         # Variable filter selector combo widget. Pass in two widgets so they
         # can be updated by the VariableSelectorInfo widget
-        self.var_selector = VariableSelectorInfo(self.de.variables, 
-                                                 daterange=self.daterange,
-                                                 frequency=self.frequency,
-                                                 rows=20)
+        self.var_selector = VariableSelectorInfo(
+            self.de.variables,
+            daterange=self.daterange,
+            frequency=self.frequency,
+            rows=20,
+        )
         # DataArray information widget
         self.data_box = HTML()
         # Data load button
         self.load_button = Button(
-            description='Load',
+            description="Load",
             disabled=False,
-            layout={'width': '20%', 'align': 'center'},
-            tooltip='Click to load data'
+            layout={"width": "20%", "align": "center"},
+            tooltip="Click to load data",
         )
-        self.info_pane = VBox([self.frequency,
-                               self.daterange],
-                               layout={'padding': '10% 0', 'width': '50%'})
-        self.centre_pane = HBox([VBox([self.var_selector]),
-                                       self.info_pane])
+        self.info_pane = VBox(
+            [self.frequency, self.daterange],
+            layout={"padding": "10% 0", "width": "50%"},
+        )
+        self.centre_pane = HBox([VBox([self.var_selector]), self.info_pane])
 
     def _set_handlers(self):
         """
         Define routines to handle button clicks and experiment selection
         """
         self.load_button.on_click(self._load_data)
-        self.expt_selector.observe(self._expt_eventhandler, names='value')
+        self.expt_selector.observe(self._expt_eventhandler, names="value")
 
     def _expt_eventhandler(self, selector):
         """
@@ -929,31 +995,46 @@ class ExperimentExplorer(VBox):
         frequency = self.frequency.value
 
         load_command = """
-        <pre><code>cc.querying.getvar('{expt}', '{var}', session, 
-                    start_time='{start}', end_time='{end}', frequency='{frequency}')</code></pre>
-        """.format(expt=self.expt_selector.value, 
-                var=varname,
-                start=str(start_time),
-                end=str(end_time),
-                frequency=str(frequency))
+        <pre><code>cc.querying.getvar('{expt}', '{var}', session,
+                    start_time='{start}', end_time='{end}',
+                    frequency='{frequency}')</code></pre>
+        """.format(
+            expt=self.expt_selector.value,
+            var=varname,
+            start=str(start_time),
+            end=str(end_time),
+            frequency=str(frequency),
+        )
 
         # Interim message to tell user what is happening
-        self.data_box.value = 'Loading data, using following command ...\n\n' + load_command + 'Please wait ... '
+        self.data_box.value = (
+            "Loading data, using following command ...\n\n"
+            + load_command
+            + "Please wait ... "
+        )
 
         try:
-            self.loaded_data = querying.getvar(self.experiment_name,
-                                               varname,
-                                               self.de.session, 
-                                               start_time=str(start_time),
-                                               end_time=str(end_time),
-                                               frequency=frequency)
+            self._loaded_data = querying.getvar(
+                self.experiment_name,
+                varname,
+                self.de.session,
+                start_time=str(start_time),
+                end_time=str(end_time),
+                frequency=frequency,
+            )
         except Exception as e:
-            self.data_box.value = self.data_box.value + 'Error loading variable {} data: {}'.format(varname, e)
+            self.data_box.value = (
+                self.data_box.value
+                + "Error loading variable {} data: {}".format(varname, e)
+            )
             return
 
         # Update data box with message about command used and pretty HTML
         # representation of DataArray
-        self.data_box.value = 'Loaded data with' + load_command + self.loaded_data._repr_html_()
+        self.data_box.value = (
+            "Loaded data with" + load_command + self._loaded_data._repr_html_() +
+            "Data can be accessed through .data attribute"
+        )
 
     def _load_experiment(self, experiment_name):
         """
@@ -963,9 +1044,12 @@ class ExperimentExplorer(VBox):
         self.de = DatabaseExtension(self.session, experiments=experiment_name)
         self.experiment_name = experiment_name
         # Add metadata
-        self.variables = pd.merge(self.de.variables, 
-                                  self.de.get_variables(self.experiment_name), 
-                                  how='inner', on=['name', 'long_name'])
+        self.variables = pd.merge(
+            self.de.variables,
+            self.de.get_variables(self.experiment_name),
+            how="inner",
+            on=["name", "long_name"],
+        )
         self._load_variables()
 
     def _load_variables(self):
@@ -975,11 +1059,12 @@ class ExperimentExplorer(VBox):
         self.var_selector.set_variables(self.variables)
         self.var_selector._filter_eventhandler(None)
 
+    @property
     def data(self):
         """
         Return xarray DataArray if one has been loaded
         """
-        if self.loaded_data is None:
-            print('No data can be returned: no variable has been loaded')
+        if self._loaded_data is None:
+            print("No data can be returned: no variable has been loaded")
 
-        return self.loaded_data
+        return self._loaded_data

--- a/cosima_cookbook/explore.py
+++ b/cosima_cookbook/explore.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 from ipywidgets import HTML, Button, VBox, HBox, Label, Layout, Select
 from ipywidgets import SelectMultiple, Tab, Text, Textarea, Checkbox
@@ -8,7 +9,7 @@ from sqlalchemy import func
 
 import cosima_cookbook
 import cosima_cookbook as cc
-from . import database, querying
+from . import database, querying 
 from .database import CFVariable, NCFile, NCExperiment, NCVar
 
 def return_value_or_empty(value):
@@ -26,7 +27,7 @@ class DatabaseExtension:
     keywords = None
     variables = None
     expt_variable_map = None
-
+    
     def __init__(self, session=None, experiments=None):
         """
         Generate and store derived information based on queries to the back end
@@ -55,10 +56,10 @@ class DatabaseExtension:
 
     def experiment_variable_map(self):
         """
-        Make a pandas table with experiment as the index and columns of name, long_name,
+        Make a pandas table with experiment as the index and columns of name, long_name, 
         coordinate flag, restart flag and model type.
         """
-        allvars = pd.concat([self.get_variables(expt) for expt in self.experiments.experiment],
+        allvars = pd.concat([self.get_variables(expt) for expt in self.experiments.experiment], 
                             keys=self.experiments.experiment)
 
         # Create a new column to flag if variable is from a restart directory
@@ -69,12 +70,12 @@ class DatabaseExtension:
 
         # There is no metadata in the files or database that will let us know which
         # model produced the output, so use a heuristic that assumes if the data
-        # resides in a directory that is named for a model type it is output from
-        # that model. Doesn't use os.path.sep as it is never envisaged this will be used
+        # resides in a directory that is named for a model type it is output from 
+        # that model. Doesn't use os.path.sep as it is never envisaged this will be used 
         # outside of a posix system
         allvars.loc[(allvars.ncfile.str.contains(r'\bocean\b')  |
                      allvars.ncfile.str.contains(r'\bocn\b')), 'model'] = 'ocean'
-        allvars.loc[(allvars.ncfile.str.contains(r'\batmosphere\b') |
+        allvars.loc[(allvars.ncfile.str.contains(r'\batmosphere\b') | 
                      allvars.ncfile.str.contains(r'\batm\b')), 'model'] = 'atmosphere'
         allvars.loc[allvars.ncfile.str.contains(r'\bice\b'), 'model'] = 'ice'
 
@@ -91,11 +92,11 @@ class DatabaseExtension:
 
     def unique_variable_list(self):
         """
-        Extract a list of all unique variable name/long_name/model/restart/coordinate
+        Extract a list of all unique variable name/long_name/model/restart/coordinate 
         combinations from the experiment keyword map
         """
         return self.expt_variable_map.reset_index(drop=True).drop_duplicates()
-
+        
     def keyword_filter(self, keywords):
         """
         Return a list of experiments matching *all* of the supplied keywords
@@ -115,7 +116,7 @@ class DatabaseExtension:
                 set(self.expt_variable_map[self.expt_variable_map.name == v].reset_index()['experiment'])
             )
         return set.intersection(*expts)
-
+    
     def get_experiment(self, experiment):
         """
         Convenience routine to return the full entry given an experiment name
@@ -153,18 +154,18 @@ class DatabaseExtension:
             q = q.filter(NCFile.frequency == frequency)
 
         return pd.DataFrame(q)
-
+    
 
 class VariableSelector(VBox):
     """
     Combo widget based on a Select box with a search panel above to live
     filter variables to Select. When a variable is selected the long name
-    attribute is displayed under the select box. There are also two
+    attribute is displayed under the select box. There are also two 
     checkboxes which hide coordinates and restart variables.
 
     Note that a dict is used to populate the Select widget, so the visible
-    value is the variable name and is accessed via the label attribute,
-    and the long name via the value attribute.
+    value is the variable name and is accessed via the label attribute, 
+    and the long name via the value attribute. 
     """
 
     variables = None
@@ -181,7 +182,7 @@ class VariableSelector(VBox):
                                    self.selector,
                                    self.info,
                                    self.filter_coords,
-                                   self.filter_restarts],
+                                   self.filter_restarts], 
                                    **kwargs)
         self.set_variables(variables)
         self._set_info()
@@ -200,7 +201,7 @@ class VariableSelector(VBox):
         )
         # Variable search
         self.search = Text(
-            placeholder='Search: start typing',
+            placeholder='Search: start typing', 
             layout={'padding': '0px 5px', 'width': 'auto', 'overflow-x': 'scroll'},
         )
         # Variable selection box
@@ -273,7 +274,7 @@ class VariableSelector(VBox):
 
     def _model_eventhandler(self, event=None):
         """
-        Filter by model
+        Filter by model 
         """
         model = self.model.value
 
@@ -333,22 +334,22 @@ class VariableSelector(VBox):
                 search_term = self.search.value
 
         self._update_selector(variables)
-
+    
     def _selector_eventhandler(self, event=None):
         """
         Update variable info when variable selected
         """
         self._set_info(self.selector.value)
-
+    
     def _set_info(self, long_name=None):
         """
-        Set long name info widget
+        Set long name info widget 
         """
         if long_name is None or long_name == '':
             long_name = '&nbsp;'
-        style = '<style>p{word-wrap: break-word}</style>'
+        style = '<style>p{word-wrap: break-word}</style>' 
         self.info.value = style + '<p>{long_name}</p>'.format(long_name=long_name)
-
+    
     def delete(self, variable_names=None):
         """
         Remove variables
@@ -369,8 +370,8 @@ class VariableSelector(VBox):
         # Delete variables
         self.variables = self.variables[~mask]
 
-        # Update selector. Use search eventhandler so the selector preserves any
-        # current search term. It is annoying to have that reset and type in again
+        # Update selector. Use search eventhandler so the selector preserves any 
+        # current search term. It is annoying to have that reset and type in again 
         # if multiple variables are to be added
         self._search_eventhandler()
 
@@ -401,7 +402,7 @@ class VariableSelectorInfo(VariableSelector):
 
         super(VariableSelectorInfo, self).__init__(variables, rows, **kwargs)
 
-        # Requires two widgets passed in as an argument. An html box where
+        # Requires two widgets passed in as an argument. An html box where 
         # extended meta-data will be displayed, and a date range widget for
         # selecting start and end times to load
         self.daterange = daterange
@@ -428,7 +429,7 @@ class VariableSelectorInfo(VariableSelector):
 
         if len(variable) == 0:
             return
-
+        
         self.frequency.options = variable.frequency
         self.frequency.index = 0
         self.frequency.disabled = False
@@ -443,10 +444,10 @@ class VariableSelectorInfo(VariableSelector):
         variable = self.variables.loc[(self.variables['name'] == variable_name) & (self.variables['frequency'] == frequency)]
         try:
             # Populate daterange widget if variable contains necessary information
-            # Convert human readable frequency to pandas compatigle frequency string
+            # Convert human readable frequency to pandas compatigle frequency string 
             freq = re.sub(r'^(\d+) (\w)(\w+)', r'\1\2', str(variable.frequency.values[0]).upper())
             dates = pd.date_range(variable.time_start.values[0], variable.time_end.values[0] , freq=freq)
-            self.daterange.options = [(i.strftime('%Y/%m/%d'), i) for i in dates]
+            self.daterange.options = [(i.strftime('%Y/%m/%d'), i) for i in dates]                
             self.daterange.value = (dates[0], dates[-1])
         except:
             pass
@@ -455,7 +456,7 @@ class VariableSelectorInfo(VariableSelector):
 
 class VariableSelectFilter(HBox):
     """
-    Combo widget which contains a VariableSelector from which variables can
+    Combo widget which contains a VariableSelector from which variables can 
     be transferred to another Select Widget to specify which variables should
     be used to filter experiments
     """
@@ -469,7 +470,7 @@ class VariableSelectFilter(HBox):
         """
         self._make_widgets(selvariables, **kwargs)
 
-        super().__init__(children=[self.selector, self.button_box, self.filter_box],
+        super().__init__(children=[self.selector, self.button_box, self.filter_box], 
                          **kwargs)
 
         self._set_observes()
@@ -502,7 +503,7 @@ class VariableSelectFilter(HBox):
             rows=10,
             layout=layout,
         )
-        self.filter_box = VBox([self.var_filter_label,
+        self.filter_box = VBox([self.var_filter_label, 
                                 self.var_filter_selected], layout=layout)
 
     def _set_observes(self):
@@ -573,14 +574,15 @@ class VariableSelectFilter(HBox):
 class DatabaseExplorer(VBox):
     """
     Combo widget based on a select box containing all experiments in
-    specified database.
+    specified database. 
     """
 
     session = None
     de = None
+    ee = None
 
     def __init__(self, session=None, de=None):
-        if de is None:
+        if de is None: 
             de = DatabaseExtension(session)
         self.de = de
 
@@ -606,14 +608,14 @@ class DatabaseExplorer(VBox):
             <h3>Database Explorer</h3>
 
             <p>Select an experiemt to show more detailed information where available.
-            With an experiment selected push 'Load Experiment' to open an Experiment
+            With an experiment selected push 'Load Experiment' to open an Experiment 
             Explorer gui.</p>
 
-            <p>The list of experiments can be filtered by keywords and/or variables.
+            <p>The list of experiments can be filtered by keywords and/or variables. 
             Multiple keywords can be selected using alt/option/ctrl (system dependent)
-            or the shift modifier when selecting. To filter by variables select a
-            variable and add it to the "Filter variables" box using the ">>" button,
-            and vice-versa to remove variables from the filter. Push the 'Filter'
+            or the shift modifier when selecting. To filter by variables select a 
+            variable and add it to the "Filter variables" box using the ">>" button, 
+            and vice-versa to remove variables from the filter. Push the 'Filter' 
             button to show only matching experiments.</p>
 
             <p>The ExperimentExplorer element is accessible as the <tt>ee</tt> attribute
@@ -621,7 +623,7 @@ class DatabaseExplorer(VBox):
             """,
             description='',
             layout={'width': '60%'},
-        )
+        ) 
 
         # Experiment selector box
         self.expt_selector = Select(
@@ -644,7 +646,7 @@ class DatabaseExplorer(VBox):
             layout={'width': '20%', 'align': 'center'},
             tooltip='Click to clear selected keywords'
         )
-        self.keyword_box = VBox([self.filter_widget,
+        self.keyword_box = VBox([self.filter_widget, 
                                  self.clear_keywords_button],
                                  layout={'flex': '0 0 40%'})
 
@@ -656,11 +658,11 @@ class DatabaseExplorer(VBox):
         )
 
         # Variable filter selector combo widget
-        self.var_filter = VariableSelectFilter(self.de.variables,
+        self.var_filter = VariableSelectFilter(self.de.variables, 
                                                layout={'flex': '0 0 40%'})
 
         # Tab box to contain keyword and variable filters
-        self.filter_tabs = Tab(title='Filter', children=[self.keyword_box,
+        self.filter_tabs = Tab(title='Filter', children=[self.keyword_box, 
                                                          self.var_filter])
         self.filter_tabs.set_title(0, 'Keyword')
         self.filter_tabs.set_title(1, 'Variable')
@@ -684,12 +686,12 @@ class DatabaseExplorer(VBox):
 
         # Some box layout nonsense to organise widgets in space
         self.selectors = HBox([
-                            VBox([Label(value="Experiments:"),
+                            VBox([Label(value="Experiments:"), 
                                 self.expt_selector,
                                 self.load_button,
                                 ],
                                 layout={'padding': '0px 5px', 'flex': '0 0 30%'}),
-                            VBox([Label(value="Filter by:"),
+                            VBox([Label(value="Filter by:"), 
                                 self.filter_tabs,
                                 self.filter_button],
                                 layout={'padding': '0px 10px', 'flex': '0 0 65%'}),
@@ -749,11 +751,11 @@ class DatabaseExplorer(VBox):
         <tr><td><b>No. files:</b></td> <td>{ncfiles}</td></tr>
         <tr><td><b>Created:</b></td> <td>{created}</td></tr>
         </table>
-        """.format(experiment=experiment_name,
+        """.format(experiment=experiment_name, 
                     **{field: return_value_or_empty(expt[field].values[0])
-                       for field in ['description', 'notes', 'contact',
+                       for field in ['description', 'notes', 'contact', 
                                      'email', 'ncfiles', 'created']})
-
+        
     def _filter_experiments(self, b):
         """
         Filter experiment list by keywords and variable
@@ -775,14 +777,24 @@ class DatabaseExplorer(VBox):
         Open an Experiment Explorer UI with selected experiment
         """
         if self.expt_selector.value is not None:
-            self.ee = ExperimentExplorer(session=self.session,
+            self.ee = ExperimentExplorer(session=self.session, 
                                          experiment=self.expt_selector.value)
             self.expt_explorer.children = [self.ee]
+
+    def data(self):
+        """
+        Return xarray DataArray if one has been loaded in ExperimentExplorer 
+        """
+        if self.ee is None:
+            print('Cannot return data if no experiment has been loaded')
+            return None
+
+        return self.ee.data()
 
 class ExperimentExplorer(VBox):
 
     session = None
-    data = None
+    loaded_data = None
     experiment_name = None
     variables = []
 
@@ -793,7 +805,7 @@ class ExperimentExplorer(VBox):
 
         if experiment is None:
             # Have to pass an experiment to DatabaseExtension so that
-            # it only creates a variable/keyword map for a single
+            # it only creates a variable/keyword map for a single 
             # experiment
             expts = querying.get_experiments(self.session, all=True)
             experiment = expts.iloc[0].experiment
@@ -818,15 +830,15 @@ class ExperimentExplorer(VBox):
         self.header = HTML(
             value="""
             <h3>Experiment Explorer</h3>
-
+            
             <p>Select a variable from the list to display metadata information.
             Where appropriate select a date range. Pressing the <b>Load</b> button
-            will read the data into an <tt>xarray DataArray</tt> using the COSIMA Cookook.
+            will read the data into an <tt>xarray DataArray</tt> using the COSIMA Cookook. 
             The command used is output and can be copied and modified as required.</p>
 
-            <p>The loaded DataArray is accessible as the <tt>data</tt> attribute
-            of the ExperimentExplorer object.</p>
-
+            <p>The loaded DataArray is accessible as the <tt>data</tt> attribute 
+            of the ExperimentExplorer object.</p> 
+            
             <p>The selected experiment can be changed to any experiment present
             in the current database session.</p>
             """,
@@ -855,7 +867,7 @@ class ExperimentExplorer(VBox):
         )
         # Variable filter selector combo widget. Pass in two widgets so they
         # can be updated by the VariableSelectorInfo widget
-        self.var_selector = VariableSelectorInfo(self.de.variables,
+        self.var_selector = VariableSelectorInfo(self.de.variables, 
                                                  daterange=self.daterange,
                                                  frequency=self.frequency,
                                                  rows=20)
@@ -896,9 +908,9 @@ class ExperimentExplorer(VBox):
         frequency = self.frequency.value
 
         load_command = """
-        <pre><code>cc.querying.getvar('{expt}', '{var}', session,
+        <pre><code>cc.querying.getvar('{expt}', '{var}', session, 
                     start_time='{start}', end_time='{end}', frequency='{frequency}')</code></pre>
-        """.format(expt=self.expt_selector.value,
+        """.format(expt=self.expt_selector.value, 
                 var=varname,
                 start=str(start_time),
                 end=str(end_time),
@@ -908,19 +920,19 @@ class ExperimentExplorer(VBox):
         self.data_box.value = 'Loading data, using following command ...\n\n' + load_command + 'Please wait ... '
 
         try:
-            self.data = querying.getvar(self.experiment_name,
-                                        varname,
-                                        self.de.session,
-                                        start_time=str(start_time),
-                                        end_time=str(end_time),
-                                        frequency=frequency)
+            self.loaded_data = querying.getvar(self.experiment_name,
+                                               varname,
+                                               self.de.session, 
+                                               start_time=str(start_time),
+                                               end_time=str(end_time),
+                                               frequency=frequency)
         except Exception as e:
             self.data_box.value = self.data_box.value + 'Error loading variable {} data: {}'.format(varname, e)
             return
 
         # Update data box with message about command used and pretty HTML
         # representation of DataArray
-        self.data_box.value = 'Loaded data with' + load_command + self.data._repr_html_()
+        self.data_box.value = 'Loaded data with' + load_command + self.loaded_data._repr_html_()
 
     def _load_experiment(self, experiment_name):
         """
@@ -930,8 +942,8 @@ class ExperimentExplorer(VBox):
         self.de = DatabaseExtension(self.session, experiments=experiment_name)
         self.experiment_name = experiment_name
         # Add metadata
-        self.variables = pd.merge(self.de.variables,
-                                  self.de.get_variables(self.experiment_name),
+        self.variables = pd.merge(self.de.variables, 
+                                  self.de.get_variables(self.experiment_name), 
                                   how='inner', on=['name', 'long_name'])
         self._load_variables()
 
@@ -941,3 +953,12 @@ class ExperimentExplorer(VBox):
         """
         self.var_selector.set_variables(self.variables)
         self.var_selector._filter_eventhandler(None)
+
+    def data(self):
+        """
+        Return xarray DataArray if one has been loaded
+        """
+        if self.loaded_data is None:
+            print('No data can be returned: no variable has been loaded')
+
+        return self.loaded_data

--- a/test/test_dates.py
+++ b/test/test_dates.py
@@ -26,7 +26,7 @@ import cftime
 from datetime import datetime, timedelta
 
 from cosima_cookbook.date_utils import rebase_times, rebase_dataset, \
-    rebase_variable, rebase_shift_attr
+    rebase_variable, rebase_shift_attr, format_datetime, parse_datetime
 
 from xarray.testing import assert_equal
 
@@ -48,6 +48,22 @@ def setup_module(module):
 def teardown_module(module):
     if verbose: print ("teardown_module   module:%s" % module.__name__)
     # Put any taerdown code in here, like deleting temporary files
+
+def test_format_parse_datetime():
+
+    dates = [cftime.num2date(t, units='days since 01-01-01', calendar='noleap') for t in times]
+    assert(format_datetime(dates[0]) == '0001-01-01 00:00:00')
+    assert(format_datetime(dates[-1]) == '0005-12-01 00:00:00')
+
+    for d in dates:
+        assert(parse_datetime(format_datetime(d), cftime.DatetimeNoLeap) == d)
+
+    dates = [cftime.num2date(t, units='days since 01-01-01', calendar='proleptic_gregorian') for t in times]
+    assert(format_datetime(dates[0]) == '0001-01-01 00:00:00')
+    assert(format_datetime(dates[-1]) == '0005-11-30 00:00:00')
+
+    for d in dates:
+        assert(parse_datetime(format_datetime(d), cftime.DatetimeProlepticGregorian) == d)
 
 def test_rebase_times():
 

--- a/test/test_dates.py
+++ b/test/test_dates.py
@@ -56,14 +56,14 @@ def test_format_parse_datetime():
     assert(format_datetime(dates[-1]) == '0005-12-01 00:00:00')
 
     for d in dates:
-        assert(parse_datetime(format_datetime(d), cftime.DatetimeNoLeap) == d)
+        assert(parse_datetime(format_datetime(d), 'noleap') == d)
 
     dates = [cftime.num2date(t, units='days since 01-01-01', calendar='proleptic_gregorian') for t in times]
     assert(format_datetime(dates[0]) == '0001-01-01 00:00:00')
     assert(format_datetime(dates[-1]) == '0005-11-30 00:00:00')
 
     for d in dates:
-        assert(parse_datetime(format_datetime(d), cftime.DatetimeProlepticGregorian) == d)
+        assert(parse_datetime(format_datetime(d), 'proleptic_gregorian') == d)
 
 def test_rebase_times():
 

--- a/test/test_explore.py
+++ b/test/test_explore.py
@@ -147,8 +147,30 @@ def test_experiment_explorer(session):
     # Check frequency drop down changes when variable selector assigned a value
     assert(ee1.frequency.options == ())
     ee1.var_selector.selector.label = 'tx_trans'
+    ee1.var_selector._set_frequency_selector('tx_trans')
+    assert(ee1.frequency.options == (None,))
+    ee1.var_selector._set_daterange_selector('ty_trans', '1 yearly')
     assert(ee1.frequency.options == (None,))
 
     ee2 = cc.explore.ExperimentExplorer(session=session)
 
     assert(id(ee1.var_selector) != id(ee2.var_selector))
+
+def test_get_data(session):
+
+    ee = cc.explore.ExperimentExplorer(session=session)
+
+    assert(ee.data() is None)
+
+    ee._load_experiment('one')
+    ee.var_selector.selector.label = 'ty_trans'
+    ee.var_selector._set_frequency_selector('ty_trans')
+    ee.var_selector._set_daterange_selector('ty_trans', '1 yearly')
+    ee._load_data(None)
+
+    assert(ee.frequency.options == ('1 yearly',))
+    assert(ee.daterange.options[0][0] == ' 166/12/31')
+    assert(ee.daterange.options[1][0] == ' 167/12/31')
+
+    assert(ee.data() is not None)
+    assert(ee.data().shape == (2, 1, 1, 1))

--- a/test/test_explore.py
+++ b/test/test_explore.py
@@ -160,7 +160,7 @@ def test_get_data(session):
 
     ee = cc.explore.ExperimentExplorer(session=session)
 
-    assert(ee.data() is None)
+    assert(ee.data is None)
 
     ee._load_experiment('one')
     ee.var_selector.selector.label = 'ty_trans'
@@ -172,5 +172,5 @@ def test_get_data(session):
     assert(ee.daterange.options[0][0] == ' 166/12/31')
     assert(ee.daterange.options[1][0] == ' 167/12/31')
 
-    assert(ee.data() is not None)
-    assert(ee.data().shape == (2, 1, 1, 1))
+    assert(ee.data is not None)
+    assert(ee.data.shape == (2, 1, 1, 1))


### PR DESCRIPTION
Closes #201 

Made dedicated `parse_datetime` and `format_datetime` routines to enforce consistent datetime <> string conversions.

Added `.data` method to `DatabaseExplorer` and `ExperimentExplorer` to provide a consistent way to access data loaded through the gui elements.