### PR TITLE
Fix test for ExperimentExplorer daterange

### DIFF
--- a/test/test_explore.py
+++ b/test/test_explore.py
@@ -197,8 +197,8 @@ def test_get_data(session):
     ee._load_data(None)
 
     assert ee.frequency.options == ("1 yearly",)
-    assert ee.daterange.options[0][0] == " 166/12/31"
-    assert ee.daterange.options[1][0] == " 167/12/31"
+    assert ee.daterange.options[0][0] == "0166/12/31"
+    assert ee.daterange.options[1][0] == "0167/12/31"
 
     assert ee.data is not None
     assert ee.data.shape == (2, 1, 1, 1)


### PR DESCRIPTION
This was previously space-padding a 3-digit year, however it seems that some change to `cftime` has caused it to now zero-pad the year. The rest of the `ExperimentExplorer` should still work with this change, but we just need to update the test to not throw an incorrect assert.

Ping @aidanheerdegen, I don't know exactly how the daterange works. Could you just confirm that this can be a test-only change, and not a change to the `ExperimentExplorer` itself?