### PR TITLE
Refactor index_experiment to take only a list of files to index.

### DIFF
--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -600,7 +600,12 @@ def build_index(
         if len(files) > 0:
             if len(expt.ncfiles) > 0:
                 # Only pass files that are not already in DB
-                files = {f.ncfile for f in session.query(NCFile).with_parent(expt).filter(NCFile.ncfile.notin_(files))}
+                files = {
+                    f.ncfile
+                    for f in session.query(NCFile)
+                    .with_parent(expt)
+                    .filter(NCFile.ncfile.notin_(files))
+                }
 
             indexed += index_experiment(files, session, expt, client)
 
@@ -621,16 +626,17 @@ def _prune_files(expt, session, files, delete=True):
 
     # Missing are physically missing from disk, or where marked as not
     # present previously. Can also be a broken file which didn't index
-    missing_ncfiles = (session.query(NCFile)
-                       .with_parent(expt)
-                       .filter(NCFile.ncfile.notin_(files) |
-                               (NCFile.present == False)) )
+    missing_ncfiles = (
+        session.query(NCFile)
+        .with_parent(expt)
+        .filter(NCFile.ncfile.notin_(files) | (NCFile.present == False))
+    )
     if missing_ncfiles.first() is not None:
         if delete:
             missing_ncfiles.delete(synchronize_session=False)
         else:
             missing_ncfiles.update({NCFile.present: False}, synchronize_session=False)
-    
+
         session.commit()
 
 
@@ -640,7 +646,7 @@ def prune_experiment(experiment, session, delete=True, followsymlinks=False):
     index time. Experiment can be either an NCExperiment object, or the
     name of an experiment available within the current session.
     """
-    
+
     if isinstance(experiment, NCExperiment):
         expt = experiment
         experiment = expt.experiment

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -479,6 +479,7 @@ def update_metadata(experiment, session):
 class IndexingError(Exception):
     pass
 
+
 def find_files(searchdir, matchstring="*.nc", followsymlinks=False):
     """Return netCDF files under search directory"""
 
@@ -500,6 +501,7 @@ def find_files(searchdir, matchstring="*.nc", followsymlinks=False):
     # make all files relative to the search directory and return as set
     return {str(Path(s).relative_to(searchdir)) for s in proc.stdout.split()}
 
+
 def find_experiment(session, expt_path):
     """Return experiment if it already exists in this DB session"""
 
@@ -510,6 +512,7 @@ def find_experiment(session, expt_path):
     )
 
     return q.one_or_none()
+
 
 def index_experiment(files, session, expt, client=None):
     """Index specified files for an experiment."""
@@ -549,13 +552,13 @@ def build_index(
 ):
     """Index all netcdf files contained within experiment directories.
 
-    Requires a session for the database that's been created with the 
-    create_session() function. If client is not None, use a distributed 
-    client for processing files in parallel. May scan for only new entries 
-    to add to database with the update flag. If prune is True files that 
-    are already in the database but are missing from the filesystem will 
-    be either removed if delete is also True, or flagged as missing if 
-    delete is False. Symbolically linked files and/or directories will be 
+    Requires a session for the database that's been created with the
+    create_session() function. If client is not None, use a distributed
+    client for processing files in parallel. May scan for only new entries
+    to add to database with the update flag. If prune is True files that
+    are already in the database but are missing from the filesystem will
+    be either removed if delete is also True, or flagged as missing if
+    delete is False. Symbolically linked files and/or directories will be
     indexed if followsymlinks is True.
 
     Returns the number of new files that were indexed.
@@ -572,16 +575,13 @@ def build_index(
 
         if expt is None:
             expt = NCExperiment(
-                experiment=str(directory.name), 
-                root_dir=str(directory.resolve())
+                experiment=str(directory.name), root_dir=str(directory.resolve())
             )
         else:
             if not update:
                 print(
                     "Not re-indexing experiment: {}\n"
-                    "Pass `update=True` to build_index()".format(
-                        directory.name
-                    )
+                    "Pass `update=True` to build_index()".format(directory.name)
                 )
                 continue
 
@@ -593,7 +593,9 @@ def build_index(
             missing_files = set([f.ncfile for f in expt.ncfiles]) - files
             if len(missing_files) > 0:
                 # Make a list of NCFile objects to pass to prune_files
-                missing_files_objs = [f for f in expt.ncfiles if f.ncfile in missing_files]
+                missing_files_objs = [
+                    f for f in expt.ncfiles if f.ncfile in missing_files
+                ]
                 prune_files(expt, session, missing_files_objs, delete=delete)
 
         # Filter conditions
@@ -601,9 +603,7 @@ def build_index(
             # Only pass files that are not already in DB
             files = files - set([f.ncfile for f in expt.ncfiles])
 
-        indexed += index_experiment(
-            files, session, expt, client
-        )
+        indexed += index_experiment(files, session, expt, client)
 
         # if everything went smoothly, commit these changes to the database
         session.commit()
@@ -612,7 +612,7 @@ def build_index(
 
 
 def prune_files(expt, session, files, delete=True):
-    """Delete or mark as not present the database entries for specified 
+    """Delete or mark as not present the database entries for specified
     files objects within the given experiment
     """
     for f in files:

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -655,8 +655,7 @@ def prune_experiment(experiment, session, delete=True, followsymlinks=False):
             .one_or_none()
         )
         if not expt:
-            logging.error("No such experiment: {}".format(experiment))
-            raise RuntimeError
+            raise RuntimeError("No such experiment: {}".format(experiment))
 
     files = find_files(expt.root_dir, followsymlinks=followsymlinks)
 

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -601,8 +601,8 @@ def build_index(
             if len(expt.ncfiles) > 0:
                 # Only pass files that are not already in DB
                 files = {
-                    f.ncfile
-                    for f in session.query(NCFile)
+                    f
+                    for f, in session.query(NCFile.ncfile)
                     .with_parent(expt)
                     .filter(NCFile.ncfile.notin_(files))
                 }

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -631,13 +631,11 @@ def _prune_files(expt, session, files, delete=True):
         .with_parent(expt)
         .filter(NCFile.ncfile.notin_(files) | (NCFile.present == False))
     )
-    if missing_ncfiles.first() is not None:
-        if delete:
-            missing_ncfiles.delete(synchronize_session=False)
-        else:
-            missing_ncfiles.update({NCFile.present: False}, synchronize_session=False)
-
-        session.commit()
+    session.expire_all()
+    if delete:
+        missing_ncfiles.delete(synchronize_session=False)
+    else:
+        missing_ncfiles.update({NCFile.present: False}, synchronize_session=False)
 
 
 def prune_experiment(experiment, session, delete=True, followsymlinks=False):

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -655,8 +655,8 @@ def prune_experiment(experiment, session, delete=True, followsymlinks=False):
             .one_or_none()
         )
         if not expt:
-            print("No such experiment: {}".format(experiment))
-            return
+            logging.error("No such experiment: {}".format(experiment))
+            raise RuntimeError
 
     files = find_files(expt.root_dir, followsymlinks=followsymlinks)
 

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -611,7 +611,7 @@ def build_index(
                     .one_or_none()
                 )
                 if existing_ncfile is not None:
-                    print('Re-indexing {}'.format(f))
+                    print("Re-indexing {}".format(f))
                     session.delete(existing_ncfile)
             session.flush()
         else:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'f90nml',
         'joblib',
         'ipywidgets',
-    ]
+    ],
 
     extras_require = {
         'build': ['distributed', 'pytest']

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ setup(
         'bokeh',
         'netcdf4',
         'tqdm',
-        'sqlalchemy',
+        'sqlalchemy<1.4',
         'cftime',
         'f90nml',
         'joblib',
         'ipywidgets',
-    ],
+    ]
 
     extras_require = {
         'build': ['distributed', 'pytest']

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -22,21 +22,21 @@ def unreadable_dir(tmpdir):
 
 def test_find_files():
 
-    files = database.find_files('test/data/indexing/')
-    assert( len(files) == 16 )
+    files = database.find_files("test/data/indexing/")
+    assert len(files) == 16
 
     for f in files:
-        assert(Path(f).suffix == '.nc')
+        assert Path(f).suffix == ".nc"
 
     # No python source files in data subdirectory
-    assert( len(database.find_files('test/data/indexing/', "*.py")) == 0 )
+    assert len(database.find_files("test/data/indexing/", "*.py")) == 0
 
     # Test works with alternative suffix
-    files = database.find_files('test/', "*.py")
-    assert( len(files) == 7 )
+    files = database.find_files("test/", "*.py")
+    assert len(files) == 7
 
     for f in files:
-        assert( Path(f).suffix == '.py' )
+        assert Path(f).suffix == ".py"
 
 
 def test_find_experiment(session_db):
@@ -48,7 +48,7 @@ def test_find_experiment(session_db):
     )
     session.add(expt)
 
-    assert( expt == database.find_experiment(session, directory) )
+    assert expt == database.find_experiment(session, directory)
 
 
 def test_index_experiment(session_db):
@@ -64,14 +64,14 @@ def test_index_experiment(session_db):
     # Index just one file
     database.index_experiment(set(list(files)[:1]), session, expt)
 
-    assert( expt == database.find_experiment(session, directory) )
-    assert( len(database.find_experiment(session, directory).ncfiles) == 1 )
+    assert expt == database.find_experiment(session, directory)
+    assert len(database.find_experiment(session, directory).ncfiles) == 1
 
     # Index the other file
     database.index_experiment(set(list(files)[1:]), session, expt)
 
-    assert( expt == database.find_experiment(session, directory) )
-    assert( len(database.find_experiment(session, directory).ncfiles) == 2 )
+    assert expt == database.find_experiment(session, directory)
+    assert len(database.find_experiment(session, directory).ncfiles) == 2
 
 
 def test_unreadable(session_db, unreadable_dir):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -83,7 +83,9 @@ def test_reindex_force(session_db):
     assert db.check()
 
     # re-run the index, make sure re-index
-    reindexed = database.build_index("test/data/indexing/broken_file", session, force=True)
+    reindexed = database.build_index(
+        "test/data/indexing/broken_file", session, force=True
+    )
     assert reindexed == 1
 
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -74,7 +74,7 @@ def test_update_nonew(session_db):
 
     # re-run the index, make sure we don't re-index anything
     reindexed = database.build_index(
-        "test/data/indexing/broken_file", session, update=True
+        "test/data/indexing/broken_file", session
     )
     assert reindexed == 0
 
@@ -100,7 +100,7 @@ def test_update_newfile(session_db, tmpdir):
     shutil.copy(
         "test/data/indexing/longnames/output000/test2.nc", str(tmpdir / "test2.nc")
     )
-    database.build_index(str(tmpdir), session, update=True)
+    database.build_index(str(tmpdir), session)
 
 
 def test_single_broken(session_db):
@@ -357,7 +357,7 @@ def test_index_with_prune_nodelete(session_db, tmpdir):
 
     # remove the file and build with pruning
     os.remove(expt_dir / "test1.nc")
-    database.build_index(str(expt_dir), session, update=True, prune=True, delete=False)
+    database.build_index(str(expt_dir), session, prune='flag')
 
     # now we should still have one file, but now not present
     q = session.query(database.NCFile)
@@ -384,7 +384,7 @@ def test_index_with_prune_delete(session_db, tmpdir):
 
     # remove the file and build with pruning
     os.remove(expt_dir / "test1.nc")
-    database.build_index(str(expt_dir), session, update=True, prune=True, delete=True)
+    database.build_index(str(expt_dir), session, prune='delete')
 
     # now we should still have no files
     q = session.query(database.NCFile)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -73,20 +73,18 @@ def test_update_nonew(session_db):
     assert db.check()
 
     # re-run the index, make sure we don't re-index anything
-    reindexed = database.build_index(
-        "test/data/indexing/broken_file", session
-    )
+    reindexed = database.build_index("test/data/indexing/broken_file", session)
     assert reindexed == 0
 
 
-def test_reindex_noupdate(session_db):
+def test_reindex_force(session_db):
     session, db = session_db
     database.build_index("test/data/indexing/broken_file", session)
     assert db.check()
 
-    # re-run the index, make sure we don't re-index anything
-    reindexed = database.build_index("test/data/indexing/broken_file", session)
-    assert reindexed == 0
+    # re-run the index, make sure re-index
+    reindexed = database.build_index("test/data/indexing/broken_file", session, force=True)
+    assert reindexed == 1
 
 
 def test_update_newfile(session_db, tmpdir):
@@ -357,7 +355,7 @@ def test_index_with_prune_nodelete(session_db, tmpdir):
 
     # remove the file and build with pruning
     os.remove(expt_dir / "test1.nc")
-    database.build_index(str(expt_dir), session, prune='flag')
+    database.build_index(str(expt_dir), session, prune="flag")
 
     # now we should still have one file, but now not present
     q = session.query(database.NCFile)
@@ -384,7 +382,7 @@ def test_index_with_prune_delete(session_db, tmpdir):
 
     # remove the file and build with pruning
     os.remove(expt_dir / "test1.nc")
-    database.build_index(str(expt_dir), session, prune='delete')
+    database.build_index(str(expt_dir), session, prune="delete")
 
     # now we should still have no files
     q = session.query(database.NCFile)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -357,7 +357,7 @@ def test_prune_missing_experiment(session_db):
 
     # prune experiment
     experiment = "incorrect_experiment"
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match='No such experiment: '.format(experiment)):
         database.prune_experiment(experiment, session)
 
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -43,6 +43,9 @@ def test_find_experiment(session_db):
     session, db = session_db
 
     directory = Path("test/data/indexing/broken_file")
+
+    assert None == database.find_experiment(session, directory)
+
     expt = database.NCExperiment(
         experiment=str(directory.name), root_dir=str(directory.resolve())
     )
@@ -339,6 +342,23 @@ def test_prune_broken(session_db):
     q = session.query(database.NCFile)
     r = q.all()
     assert len(r) == 0
+
+
+def test_prune_missing_experiment(session_db):
+    session, db = session_db
+    database.build_index("test/data/indexing/broken_file", session)
+
+    assert db.check()
+
+    # check that we have one file
+    q = session.query(database.NCFile)
+    r = q.all()
+    assert len(r) == 1
+
+    # prune experiment
+    experiment = "incorrect_experiment"
+    with pytest.raises(RuntimeError):
+        database.prune_experiment(experiment, session)
 
 
 def test_prune_nodelete(session_db, tmpdir):

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -357,7 +357,7 @@ def test_prune_missing_experiment(session_db):
 
     # prune experiment
     experiment = "incorrect_experiment"
-    with pytest.raises(RuntimeError, match='No such experiment: '.format(experiment)):
+    with pytest.raises(RuntimeError, match="No such experiment: ".format(experiment)):
         database.prune_experiment(experiment, session)
 
 


### PR DESCRIPTION
Closes #233 

Logic about which files to filter and prune is moved up to build_index.

Added prune_files function which is called from prune_experiment and
build_index where required.

Made a dedicated file_files function with option to specify a pattern
to match when globbing.