### PR TITLE
Fix variable filtering in DatabaseExplorer

### DIFF
--- a/cosima_cookbook/explore.py
+++ b/cosima_cookbook/explore.py
@@ -66,7 +66,7 @@ class DatabaseExtension:
         allvars = pd.concat(
             [self.get_variables(expt) for expt in self.experiments.experiment],
             keys=set(self.experiments.experiment),
-        )
+        ).rename_axis(["experiment", "number"], axis="rows")
 
         # Create a new column to flag if variable is from a restart directory
         allvars["restart"] = allvars.ncfile.str.contains("restart")

--- a/test/test_explore.py
+++ b/test/test_explore.py
@@ -143,7 +143,7 @@ def test_database_extension(session):
     assert de.variables[de.variables.model == ""].shape == (12, 5)
 
     # import pdb; pdb.set_trace()
-    assert de.variable_filter(['salt']) == {'two'}
+    assert de.variable_filter(["salt"]) == {"two"}
 
 
 def test_database_explorer(session):

--- a/test/test_explore.py
+++ b/test/test_explore.py
@@ -142,6 +142,9 @@ def test_database_extension(session):
     assert de.variables[de.variables.model == "ice"].shape == (0, 5)
     assert de.variables[de.variables.model == ""].shape == (12, 5)
 
+    # import pdb; pdb.set_trace()
+    assert de.variable_filter(['salt']) == {'two'}
+
 
 def test_database_explorer(session):
 


### PR DESCRIPTION
Closes #258 

Explicitly name index columns so that reference to experiment column works correctly in variable_filter