### PR TITLE
Add list of ncfiles as attribute to DataArray

### DIFF
--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -229,8 +229,10 @@ def getvar(
         # like time_bounds
         return d[variables]
 
+    ncfiles = list(str(f.NCFile.ncfile_path) for f in ncfiles)
+    
     ds = xr.open_mfdataset(
-        (str(f.NCFile.ncfile_path) for f in ncfiles),
+        ncfiles,
         parallel=True,
         combine="by_coords",
         preprocess=_preprocess,
@@ -241,6 +243,8 @@ def getvar(
 
     for attr in variables[1:]:
         da.attrs[attr] = ds[attr]
+
+    da.attrs['ncfiles'] = ncfiles 
 
     return da
 

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -230,7 +230,7 @@ def getvar(
         return d[variables]
 
     ncfiles = list(str(f.NCFile.ncfile_path) for f in ncfiles)
-    
+
     ds = xr.open_mfdataset(
         ncfiles,
         parallel=True,
@@ -244,7 +244,7 @@ def getvar(
     for attr in variables[1:]:
         da.attrs[attr] = ds[attr]
 
-    da.attrs['ncfiles'] = ncfiles 
+    da.attrs["ncfiles"] = ncfiles
 
     return da
 

--- a/test/test_querying.py
+++ b/test/test_querying.py
@@ -35,8 +35,8 @@ def session(tmpdir_factory):
 def test_valid_query(session):
     with cc.querying.getvar("querying", "temp", session, decode_times=False) as v:
         assert isinstance(v, xr.DataArray)
-        assert len(v.attrs['ncfiles']) == 1
-        assert v.attrs['ncfiles'][0].endswith('test/data/querying/output000/ocean.nc')
+        assert len(v.attrs["ncfiles"]) == 1
+        assert v.attrs["ncfiles"][0].endswith("test/data/querying/output000/ocean.nc")
 
 
 def test_invalid_query(session):

--- a/test/test_querying.py
+++ b/test/test_querying.py
@@ -35,6 +35,8 @@ def session(tmpdir_factory):
 def test_valid_query(session):
     with cc.querying.getvar("querying", "temp", session, decode_times=False) as v:
         assert isinstance(v, xr.DataArray)
+        assert len(v.attrs['ncfiles']) == 1
+        assert v.attrs['ncfiles'][0].endswith('test/data/querying/output000/ocean.nc')
 
 
 def test_invalid_query(session):


### PR DESCRIPTION
Closes #263 

To make the operation of `getvar` transparent it is useful to include the list of files opened for the variable. 

The most straightforward way to do this is add an `ncfiles` attribute to the returned `DataArray`.

This is means the `ncfiles` list is exposed in the `repr` for the `DataArray`, which is a good, and bad, thing, depending on your opinion, e.g.
```
<xarray.DataArray 'temp' (time: 0, st_ocean: 75, yt_ocean: 1080, xt_ocean: 1440)>
dask.array<open_dataset-d1757fe6cb749f6c183b58355066cf8atemp, shape=(0, 75, 1080, 1440), dtype=float32, chunksize=(0, 15,
216, 288), chunktype=numpy.ndarray>                                                                                       
Coordinates:                                
  * st_ocean  (st_ocean) float64 9.969e+36 9.969e+36 ... 9.969e+36 9.969e+36                                              
  * time      (time) float64 
  * xt_ocean  (xt_ocean) float64 9.969e+36 9.969e+36 ... 9.969e+36 9.969e+36
  * yt_ocean  (yt_ocean) float64 9.969e+36 9.969e+36 ... 9.969e+36 9.969e+36                                              
Attributes:                                                                                                               
    long_name:      Potential temperature                                                             
    units:          degrees K                                                                                            
    valid_range:    [-10. 500.]            
    cell_methods:   time: mean                                                                                            
    time_avg_info:  average_T1,average_T2,average_DT                                                                     
    coordinates:    geolon_t geolat_t                                
    standard_name:  sea_water_potential_temperature
    time_bounds:    <xarray.DataArray 'time_bounds' (time: 0, nv: 2)>\ndask.a...                                          
    ncfiles:        ['/home/502/aph502/code/python/cosima-cookbook/test/data/...    
```

Another option would be to subclass `xarray.DataArray` and an `ncfiles` property, but I'm not keen to go down this route without some compelling reasons.

Whaddyareckon @aekiss @angus-g ?