### PR TITLE
Pinned version of sqlalchemy<1.4 in conda

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,7 +26,7 @@ requirements:
         - netcdf4
         - joblib
         - tqdm
-        - sqlalchemy
+        - sqlalchemy<1.4
         - ipywidgets
         - cftime>1.2.1
         - lxml


### PR DESCRIPTION
Pinned sqlalchemy to <1.4 until #236 is fixed.