### PR TITLE
Add warning message for invalid chunks

### DIFF
--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -367,6 +367,13 @@ def getvar(
 
     da = ds[variable]
 
+    # Check the chunks given were actually in the data
+    chunks = xr_kwargs.get('chunks', None)
+    if chunks is not None:
+        missing_chunk_dims = set(chunks.keys()) - set(da.dims)
+        if len(missing_chunk_dims) > 0:
+            logging.warning(f"chunking along dimensions {missing_chunk_dims} is not possible. Available dimensions for chunking are {set(da.dims)}")
+
     for attr in variables[1:]:
         da.attrs[attr] = ds[attr]
 

--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -368,11 +368,13 @@ def getvar(
     da = ds[variable]
 
     # Check the chunks given were actually in the data
-    chunks = xr_kwargs.get('chunks', None)
+    chunks = xr_kwargs.get("chunks", None)
     if chunks is not None:
         missing_chunk_dims = set(chunks.keys()) - set(da.dims)
         if len(missing_chunk_dims) > 0:
-            logging.warning(f"chunking along dimensions {missing_chunk_dims} is not possible. Available dimensions for chunking are {set(da.dims)}")
+            logging.warning(
+                f"chunking along dimensions {missing_chunk_dims} is not possible. Available dimensions for chunking are {set(da.dims)}"
+            )
 
     for attr in variables[1:]:
         da.attrs[attr] = ds[attr]

--- a/test/test_querying.py
+++ b/test/test_querying.py
@@ -634,6 +634,9 @@ def test_query_with_attrs(session):
             "querying", "salt", session, decode_times=False, attrs={"not_found": "psu"}
         )
 
+
 def test_query_chunks(session, caplog):
-    with cc.querying.getvar("querying", "ty_trans", session, chunks={'invalid': 99}) as v:
+    with cc.querying.getvar(
+        "querying", "ty_trans", session, chunks={"invalid": 99}
+    ) as v:
         assert "chunking along dimensions {'invalid'} is not possible" in caplog.text

--- a/test/test_querying.py
+++ b/test/test_querying.py
@@ -633,3 +633,7 @@ def test_query_with_attrs(session):
         cc.querying.getvar(
             "querying", "salt", session, decode_times=False, attrs={"not_found": "psu"}
         )
+
+def test_query_chunks(session, caplog):
+    with cc.querying.getvar("querying", "ty_trans", session, chunks={'invalid': 99}) as v:
+        assert "chunking along dimensions {'invalid'} is not possible" in caplog.text


### PR DESCRIPTION
Warn the user if the chunk dimensions given in getvar are not actually
dimensions in the variable

Fixes #281