### PR TITLE
Reorder attribute cache lookups

### DIFF
--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -179,6 +179,9 @@ def _setup_ncattribute(session, attr_object):
     if cache is None:
         session._ncattribute_cache = cache = {}
 
+    if attr_object.value in cache:
+        return cache[attr_object.value]
+
     with session.no_autoflush:
         r = (
             session.query(NCAttributeString)
@@ -187,9 +190,6 @@ def _setup_ncattribute(session, attr_object):
         )
         if r is not None:
             return r
-
-    if attr_object.value in cache:
-        return cache[attr_object.value]
 
     cache[attr_object.value] = attr_object
     return attr_object
@@ -552,7 +552,7 @@ def create_session(db=None, debug=False):
     Base.metadata.create_all(conn)
     conn.close()
 
-    Session = sessionmaker(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False)
     return Session()
 
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -55,6 +55,7 @@ def test_find_experiment(session_db):
         experiment=str(directory.name), root_dir=str(directory.resolve())
     )
     session.add(expt)
+    session.flush()
 
     assert expt == database.find_experiment(session, directory)
 
@@ -71,6 +72,7 @@ def test_index_experiment(session_db):
 
     # Index just one file
     database.index_experiment(set(list(files)[:1]), session, expt)
+    session.flush()
 
     assert expt == database.find_experiment(session, directory)
     assert len(database.find_experiment(session, directory).ncfiles) == 1


### PR DESCRIPTION
The cache lookup was moved to be after a query, because the proper ordering was breaking not-null constraints. It seems that this was due to sqlalchemy's propensity to autoflush the session when queries are issued. This is probably a reasonable optimisation in most cases, but we rely on being able to normalise the objects within the session before they're committed to the database.

To allow us to reorder the lookup, we disable autoflush on the session. This will have no impact on database readers (i.e. most users). Writers who wish to query the database within the same session as writing may have to issue a manual flush. Two flushes are added to the test suite, where this was the case.

Closes #290.

Rough testing of `build_index()` on `panant-01-hycom1` (414 files) shows about 65s user time before the change, and 20s after it.