### PR TITLE
Python 3.10 compatibility / Test suite tweaks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         sqa-version: ['<1.4', '==1.4.*']
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         sqa-version: ['<1.4', '==1.4.*']
 
     steps:

--- a/cosima_cookbook/explore.py
+++ b/cosima_cookbook/explore.py
@@ -198,8 +198,13 @@ class VariableSelector(VBox):
         """
         Called when filter button pushed
         """
+        if self.model.value:
+            model_value = self.model_value
+        else:
+            model_value = ""
+
         self._filter_variables(
-            self.filter_coords.value, self.filter_restarts.value, self.model.value
+            self.filter_coords.value, self.filter_restarts.value, model_value
         )
 
     def _filter_variables(self, coords=True, restarts=True, model=""):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,8 +12,8 @@ def client():
 
 
 @pytest.fixture(scope="function")
-def session_db(tmpdir):
-    db = tmpdir.join("test.db")
+def session_db(tmp_path):
+    db = tmp_path / "test.db"
     s = database.create_session(str(db))
     yield s, db
 

--- a/test/test_explore.py
+++ b/test/test_explore.py
@@ -42,10 +42,10 @@ def metadata_for_experiment(
 
 
 @pytest.fixture(scope="module")
-def session(tmpdir_factory):
+def session(tmp_path_factory):
     # index test directory into temp database
-    d = tmpdir_factory.mktemp("database")
-    db = d.join("test.db")
+    d = tmp_path_factory.mktemp("database")
+    db = d / "test.db"
     session = cc.database.create_session(str(db))
 
     # build index for entire module

--- a/test/test_querying.py
+++ b/test/test_querying.py
@@ -15,10 +15,10 @@ from cosima_cookbook.database import NCFile, CFVariable
 
 
 @pytest.fixture(scope="module")
-def session(tmpdir_factory):
+def session(tmp_path_factory):
     # index test directory into temp database
-    d = tmpdir_factory.mktemp("database")
-    db = d.join("test.db")
+    d = tmp_path_factory.mktemp("database")
+    db = d / "test.db"
     session = cc.database.create_session(str(db))
 
     # build index for entire module

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -2,11 +2,11 @@ import shlex
 from cosima_cookbook import database_update
 
 
-def test_database_update(tmpdir):
+def test_database_update(tmp_path):
 
     args = shlex.split(
         "-db {db} test/data/update/experiment_a test/data/update/experiment_b".format(
-            db=tmpdir.join("test.db")
+            db=tmp_path / "test.db"
         )
     )
 


### PR DESCRIPTION
Hi, 

I have just fixed a small issue with python 3.10.
Note that it is unclear to me whether the default value for the dropdown selector should be `None` or an empty string `" " `.
Anyway I have just done the minimum change so that nothing breaks.

I have also changed `tmpdir` to `tmp_path` in the tests.
The `tmpdir` fixture relies on the legacy `py.path.local` that is not really used anymore.
`tmp_path` uses the standard `pathlib.Path` objects.

I have updated the CI to test for python 3.8, 3.9, 3.10
Note that I have dropped python 3.7 as it is not supported anymore by `xarray` since last january.
python 3.7 is rather old now and has all sorts of issues so I would advice against maintaining compatibility for it...
Versions 3.8, 3.9 and 3.10 are now on Gadi.

We (ACCESS-NRI MED) are working on improving the performance on Gadi. 
@echus @AndyHoggANU 

Romain