### PR TITLE
Correct dictionary syntax in QueryWarning about ambiguous attributes

### DIFF
--- a/cosima_cookbook/querying.py
+++ b/cosima_cookbook/querying.py
@@ -520,7 +520,7 @@ def _ncfiles_for_variable(
             warnings.warn(
                 f"Your query returns variables from files with different {attr}: {unique_attributes}. "
                 "This could lead to unexpected behaviour! Disambiguate by passing "
-                f"attrs={{'{attr}'=''}} to getvar, specifying the desired attribute value.",
+                f"attrs={{'{attr}':''}} to getvar, specifying the desired attribute value.",
                 QueryWarning,
             )
 


### PR DESCRIPTION
Closes #317 