### PR TITLE
Pin sqlalchemy<2.0

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,7 +26,7 @@ requirements:
         - netcdf4
         - joblib
         - tqdm
-        - sqlalchemy
+        - sqlalchemy<2.0
         - ipywidgets
         - cftime>1.2.1
         - lxml

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'bokeh',
         'netcdf4',
         'tqdm',
-        'sqlalchemy',
+        'sqlalchemy<2.0',
         'cftime',
         'f90nml',
         'joblib',


### PR DESCRIPTION
The cosima-cookbook doesn't work with sqlalchemy 2 - see #320. This PR pins sqlalchemy to < 2.0.