### PR TITLE
Stop capturing all warnings

### DIFF
--- a/cosima_cookbook/__init__.py
+++ b/cosima_cookbook/__init__.py
@@ -3,13 +3,13 @@
 Common tools for working with COSIMA model output
 """
 
-import pkg_resources
-
 from . import database
 from . import querying
 from . import explore
 
+from importlib.metadata import version, PackageNotFoundError
+
 try:
-    __version__ = pkg_resources.get_distribution("cosima-cookbook").version
-except Exception:
-    __version__ = "999"
+    __version__ = version("cosima-cookbook")
+except PackageNotFoundError:
+    pass

--- a/cosima_cookbook/database.py
+++ b/cosima_cookbook/database.py
@@ -42,8 +42,6 @@ from . import netcdf_utils
 from .database_utils import *
 from .date_utils import format_datetime
 
-logging.captureWarnings(True)
-
 __DB_VERSION__ = 3
 __DEFAULT_DB__ = "/g/data/ik11/databases/cosima_master.db"
 
@@ -731,7 +729,8 @@ def find_files(searchdir, matchstring="*.nc", followsymlinks=False):
     )
     if proc.returncode != 0:
         warnings.warn(
-            "Some files or directories could not be read while finding output files: %s",
+            "Some files or directories could not be read "
+            f"while finding output files: {proc.stderr[:200]}",
             UserWarning,
         )
 


### PR DESCRIPTION
I expect this might make the indexing output more verbose, since permission errors won't go through the logging mechanism.

There's an additional update to the version mechanism to make it compatible with newer Python versions where `pkg_resources` no longer exists.

Closes #337.